### PR TITLE
PoC of local/remote batch

### DIFF
--- a/qubosolver/batch.py
+++ b/qubosolver/batch.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import time
+from typing import Protocol, Sequence, TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from typing import Self
+
+from pulser.backend import Results
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, CancelledError
+
+from pulser.backend.remote import (
+    RemoteResults,
+    RemoteResultsError,
+    BatchStatus,
+    RemoteConnection,
+)
+
+# Implement the concept of concurrent.futures.Future
+class BatchConcept(Protocol):
+
+    def cancel(self: Self) -> bool: ...
+    def cancelled(self: Self) -> bool: ...
+    def running(self: Self) -> bool: ...
+    def done(self: Self) -> bool: ...
+    def result(self: Self, timeout: float|None = None) -> Sequence[Results]: ...
+    def exception(self: Self, timeout: float|None = None) -> BaseException | None: ...
+
+def from_future(function: Callable[..., Sequence[Results]], *args: Any, **kwargs: Any) -> BatchConcept:
+    executor = ThreadPoolExecutor()
+    future = executor.submit(function, *args, **kwargs)
+    executor.shutdown(wait=False)
+    return future
+
+def from_remote_results(remote_results: RemoteResults) -> BatchConcept:
+    return PulserBatch(remote_results)
+
+def from_batch_id(batch_id: str, connection: RemoteConnection) -> BatchConcept:
+    return from_remote_results(RemoteResults(batch_id, connection))
+
+class PulserBatch:
+
+    def __init__(self, remote_results: RemoteResults) -> None:
+        self._remote_results = remote_results
+
+    @property
+    def batch_id(self) -> str:
+        return self._remote_results.batch_id
+
+    def _status(self) -> BatchStatus:
+        return self._remote_results.get_batch_status()
+
+    def cancel(self) -> bool:
+        raise NotImplementedError("A Pulser Batch cannot be cancelled by user")
+
+    def cancelled(self) -> bool:
+        return self._status() == BatchStatus.CANCELED
+
+    def running(self) -> bool:
+        return self._status() in [
+            BatchStatus.RUNNING,
+            BatchStatus.PENDING,
+            BatchStatus.PAUSED,
+        ]
+
+    def done(self) -> bool:
+        return self._status() in [
+            BatchStatus.DONE,
+            BatchStatus.TIMED_OUT,
+            BatchStatus.ERROR,
+        ] or self.cancelled()
+
+    def result(self, timeout: float | None = None) -> Sequence[Results]:
+
+        start_time = time.time()
+
+        while True:
+            status = self._status()
+
+            # Check if cancelled
+            if self.cancelled():
+                raise CancelledError("Batch was cancelled")
+
+            # Check if done
+            if status == BatchStatus.DONE:
+                # Fetch and return the results
+                return self._remote_results.results
+
+            # Check if error occurred
+            if status == BatchStatus.ERROR:
+                # Try to get results which may contain error information
+                raise RemoteResultsError("Batch finished with unknown error")
+
+            if status == BatchStatus.TIMED_OUT:
+                raise RemoteResultsError("Batch timed out on the remote backend")
+
+            # Check timeout
+            if timeout is not None:
+                elapsed = time.time() - start_time
+                if elapsed >= timeout:
+                    raise TimeoutError(f"Batch did not complete within {timeout} seconds")
+
+            # Wait a bit before checking again
+            time.sleep(0.1)
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        try:
+            self.result(timeout=timeout)
+        except (CancelledError, TimeoutError) as e:
+            raise e
+        except BaseException as e:
+            return e
+        return None

--- a/qubosolver/pipeline/basesolver.py
+++ b/qubosolver/pipeline/basesolver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 from qoolqit import Register, Drive, QuantumProgram
@@ -11,6 +11,11 @@ from qubosolver.config import SolverConfig
 from qubosolver.data import QUBOSolution
 from qubosolver.qubo_types import SolutionStatusType
 from qubosolver.pipeline.fixtures import Fixtures
+
+from pulser.backend import Results
+from qoolqit.execution.backends import PulserRemoteBackend
+
+import qubosolver.batch as batch
 
 
 class BaseSolver(ABC):
@@ -84,7 +89,32 @@ class BaseSolver(ABC):
         """
         pass
 
-    def execute(self, drive: Drive, embedding: Register) -> tuple:
+    def submit(self, drive: Drive, embedding: Register) -> batch.BatchConcept:
+        program = QuantumProgram(
+            register=embedding,
+            drive=drive,
+        )
+        program.compile_to(self.device)
+        if isinstance(self.backend, PulserRemoteBackend):
+            return batch.from_remote_results(self.backend.submit(program))
+        else:
+            return batch.from_future(self.backend.run, program)
+
+    @staticmethod
+    def parse_results(results: Sequence[Results]) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Parse the remote results from the backend.
+
+        Returns:
+            tuple: A tuple of (bitstrings, counts) from the execution.
+        """
+        counter = results[-1].final_bitstrings
+        bitstrings = torch.tensor([list(map(int, list(b))) for b in list(counter.keys())])
+        counts = torch.tensor(list(counter.values()))
+
+        return bitstrings, counts
+
+    def execute(self, drive: Drive, embedding: Register) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Execute the drive schedule on the backend and retrieve the solution.
         # TODO: We do not currently execute using the async run.
@@ -104,18 +134,7 @@ class BaseSolver(ABC):
         )
         program.compile_to(self.device)
         execution_results = self.backend.run(program)
-
-        if isinstance(execution_results, tuple):
-            # local emulator result
-            execution_result = execution_results[-1]
-            counter = execution_result.final_bitstrings
-        else:
-            # remote emulator result
-            execution_result = execution_results[-1]
-            counter = execution_result.bitstring_counts
-
-        bitstrings = torch.tensor([list(map(int, list(b))) for b in list(counter.keys())])
-        counts = torch.tensor(list(counter.values()))
+        bitstrings, counts = self.parse_results(execution_results)
 
         if self.config.drive_shaping.optimized_re_execute_opt_drive and (
             bitstrings.numel() == 0 or counts.numel() == 0
@@ -125,17 +144,8 @@ class BaseSolver(ABC):
                 drive=drive,
             )
             program.compile_to(self.device)
-            execution_result = self.backend.run(program)
-            if isinstance(execution_result, tuple):
-                # local emulator result
-                execution_result = execution_result[-1]
-                counter = execution_result.final_bitstrings
-            else:
-                # remote emulator result
-                execution_result = execution_result[-1]
-                counter = execution_result.bitstring_counts
-            bitstrings = torch.tensor([list(map(int, list(b))) for b in list(counter.keys())])
-            counts = torch.tensor(list(counter.values()))
+            execution_results = self.backend.run(program)
+            bitstrings, counts = self.parse_results(execution_results)
 
         return bitstrings, counts
 

--- a/tests/test_batch_id.py
+++ b/tests/test_batch_id.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+
+import pytest
+import pytest_check as check
+import numpy as np
+import torch
+import typing
+
+from pulser.backend.remote import (
+    BatchStatus,
+    JobStatus,
+    RemoteConnection,
+    RemoteResults,
+)
+from pulser.result import Result
+
+from qubosolver.qubo_analyzer import QUBOAnalyzer
+from qubosolver.config import (
+    EmbeddingConfig,
+    DriveShapingConfig,
+    SolverConfig,
+    LocalEmulator,
+    RemoteEmulator,
+)
+from qubosolver.qubo_types import EmbedderType, DriveType
+from qubosolver.solver import QUBOInstance, QuboSolverQuantum, QUBOSolution
+
+import qubosolver.batch as batch
+
+
+class _MockConnection(RemoteConnection):
+    def __init__(self, local_result):
+        self.result = local_result
+        # self.result.bitstring_counts = self.result.final_bitstrings
+        self.results = dict()
+
+        self._status_calls = 0
+        self._support_open_batch = True
+        self._got_closed = ""
+        self._progress_calls = 0
+
+    def submit(
+        self,
+        sequence,
+        wait: bool = False,
+        open: bool = False,
+        batch_id: str | None = None,
+        **kwargs,
+    ) -> RemoteResults:
+        if not batch_id:
+            batch_id = "abcd"
+        self.results[batch_id] = self.result
+
+        return RemoteResults(batch_id, self)
+
+    def _fetch_result(
+        self, batch_id: str, job_ids: list[str] | None = None
+    ) -> typing.Sequence[Result]:
+        return (self.results[batch_id],)
+
+    def _query_job_progress(
+        self, batch_id: str
+    ) -> typing.Mapping[str, tuple[JobStatus, Result | None]]:
+        if batch_id not in self.results.keys():
+            return {batch_id: (JobStatus.ERROR, None)}
+        return {batch_id: (JobStatus.DONE, self.results[batch_id])}
+
+    def _get_batch_status(self, batch_id: str) -> BatchStatus:
+        if batch_id not in self.results.keys():
+            return BatchStatus.ERROR
+        return BatchStatus.DONE
+
+    def _close_batch(self, batch_id: str) -> None:
+        self._got_closed = batch_id
+
+    def supports_open_batch(self) -> bool:
+        return bool(self._support_open_batch)
+
+
+@pytest.mark.usefixtures("restore_rng_state")
+@pytest.mark.parametrize("drive_method", list(DriveType))
+@pytest.mark.parametrize("embedding_method", list(EmbedderType))
+@pytest.mark.parametrize("preprocessing", [True, False])
+@pytest.mark.parametrize("dmm", [True, False])
+def test_quantum_batch_id(
+    drive_method: str,
+    embedding_method: str,
+    preprocessing: bool,
+    dmm: bool,
+) -> None:
+    if embedding_method is EmbedderType.BLADE:
+        pytest.skip(reason="Blade embedding still has bugs")
+    if drive_method == DriveType.OPTIMIZED:
+        pytest.skip(reason="Does not work with the optimized drive shaping method")
+
+    np.random.seed(7979)
+
+    Q = np.array(
+        [
+            [0.0, 19.7365809, 19.7365809, 5.42015853, 5.42015853],
+            [19.7365809, -10.0, 20.67626392, 0.17675796, 0.85604541],
+            [19.7365809, 20.67626392, -10.0, 0.85604541, 0.17675796],
+            [5.42015853, 0.17675796, 0.85604541, -10.0, 0.32306662],
+            [5.42015853, 0.85604541, 0.17675796, 0.32306662, -10.0],
+        ]
+    )
+
+    def pre(connection: RemoteConnection | None = None) -> typing.Any:
+        instance = QUBOInstance(Q)
+
+        config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing)
+        config.embedding = EmbeddingConfig(
+            embedding_method=embedding_method, greedy_spacing=7.0, greedy_traps=100
+        )
+        config.drive_shaping = DriveShapingConfig(drive_shaping_method=drive_method, dmm=dmm)
+        runs = 50
+
+        if connection is None:
+            config.backend = LocalEmulator(runs=runs)
+        else:
+            config.backend = RemoteEmulator(connection=connection, runs=runs)
+
+        solver = QuboSolverQuantum(instance, config)
+
+        solver._check_size_limit()
+
+        # 2) Apply preprocessing if requested
+        solver.preprocess()
+
+        embedding = solver.embedding()
+        drive, _ = solver.drive(embedding)
+        batch = solver.submit(drive, embedding)
+
+        return batch, solver
+
+    def post(batch: typing.Any, solver: typing.Any) -> typing.Any:
+        bitstrings, counts = QuboSolverQuantum.parse_results(batch.result())
+
+        solution = QUBOSolution(
+            bitstrings=bitstrings.float(),
+            counts=counts,
+            costs=torch.Tensor(),
+            probabilities=None,
+        )
+
+        # Post-process fixations of the preprocessing and restore the original QUBO
+        solution = solver.post_process_fixation(solution)
+        solution = solver.post_process(solution)
+
+        solution.costs = solution.compute_costs(solver.instance)
+        solution.probabilities = solution.compute_probabilities()
+        solution.sort_by_cost()
+
+        solution.bitstrings = solution.bitstrings.int()
+
+        return solution
+
+    local_batch, local_solver = pre()
+    local_solution = post(local_batch, local_solver)
+
+    connection = _MockConnection(local_batch.result()[0])
+    remote_batch, remote_solver = pre(connection)
+    print(f"\nBatch ID: {remote_batch.batch_id}")
+
+    remote_batch_2 = batch.from_batch_id(remote_batch.batch_id, connection)
+    # TODO: name resume(). Add a filed resumed to check if the solver is complete or not
+    remote_solution = post(remote_batch_2, remote_solver)
+
+    torch.testing.assert_close(remote_solution.bitstrings, local_solution.bitstrings)
+    torch.testing.assert_close(remote_solution.costs, local_solution.costs)
+    torch.testing.assert_close(remote_solution.probabilities, local_solution.probabilities)
+    torch.testing.assert_close(remote_solution.counts, local_solution.counts)
+
+    analyzer = QUBOAnalyzer([local_solution, remote_solution], labels=["local", "remote"])
+    print(f"\n{analyzer.df}")
+
+    expected_solutions = ["00111", "01011"]
+
+    for label in ["local", "remote"]:
+        df = analyzer.df.query(f"labels == '{label}'")
+
+        check.is_true(df["bitstrings"].is_unique)
+
+        probabilities = [
+            df.set_index("bitstrings")["probs"].get(b, 0.0) for b in expected_solutions
+        ]
+        check.greater(max(probabilities), 0.4)
+
+        for b in expected_solutions:
+            if b in df["bitstrings"].values:
+                cost = df.set_index("bitstrings")["costs"].get(b)
+                np.testing.assert_allclose(cost, -27.288260)


### PR DESCRIPTION
This is an example of how both local and remote backend could be called with the same async result.
I opted for the API of `concurrent.futures.Future` but that's just an example.
Something similar is done in Qiskit, Cirq and Braket (with job)