### PR TITLE
[Embedding] Better defaults of the greedy embedder

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -69,7 +69,7 @@ from qubosolver.config import SolverConfig, EmbeddingConfig
 coefficients = [[0, 1, 2], [1, 0, 3], [2, 3, 0]]
 instance = QUBOInstance(coefficients=coefficients)
 
-embedding_config = EmbeddingConfig(embedding_method="greedy", greedy_traps=instance.size)
+embedding_config = EmbeddingConfig(embedding_method="greedy", greedy_traps=500)
 
 config = SolverConfig(
     config_name="my_config",
@@ -91,6 +91,6 @@ config = SolverConfig.from_kwargs(
     config_name="my_config",
     use_quantum=True,
     embedding_method="greedy",
-    greedy_traps=instance.size
+    greedy_traps=500
 )
 ```

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -69,7 +69,7 @@ from qubosolver.config import SolverConfig, EmbeddingConfig
 coefficients = [[0, 1, 2], [1, 0, 3], [2, 3, 0]]
 instance = QUBOInstance(coefficients=coefficients)
 
-embedding_config = EmbeddingConfig(embedding_method="greedy", greedy_traps=500)
+embedding_config = EmbeddingConfig(embedding_method="greedy", greedy_traps=-1)
 
 config = SolverConfig(
     config_name="my_config",
@@ -91,6 +91,6 @@ config = SolverConfig.from_kwargs(
     config_name="my_config",
     use_quantum=True,
     embedding_method="greedy",
-    greedy_traps=500
+    greedy_traps=-1
 )
 ```

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -45,12 +45,12 @@ register = solver.embedding()
 ```
 
 ## Greedy embedder config
-The following uses the greedy embedding method on a triangular lattice layout with a number of traps (`greedy_traps`) equals to the size of the QUBO. It also allows working on a square lattice layout, as well as increasing the number of traps according to the device specifications.
+The following uses the greedy embedding method on a triangular lattice layout with 500 traps (`greedy_traps`). It also allows working on a square lattice layout, as well as increasing the number of traps according to the device specifications.
 
 ```python exec="on" source="material-block" html="1" session="embedding"
 from qoolqit import AnalogDevice
 
-embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=instance.size, greedy_layout="triangular",)
+embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=500), greedy_layout="triangular",)
 greedy_config = SolverConfig(
     use_quantum=True,
     embedding=embedconfig,

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -50,7 +50,7 @@ The following uses the greedy embedding method on a triangular lattice layout wi
 ```python exec="on" source="material-block" html="1" session="embedding"
 from qoolqit import AnalogDevice
 
-embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=500), greedy_layout="triangular",)
+embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=500, greedy_layout="triangular")
 greedy_config = SolverConfig(
     use_quantum=True,
     embedding=embedconfig,

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -45,12 +45,12 @@ register = solver.embedding()
 ```
 
 ## Greedy embedder config
-The following uses the greedy embedding method on a triangular lattice layout with 500 traps (`greedy_traps`). It also allows working on a square lattice layout, as well as increasing the number of traps according to the device specifications.
+The following uses the greedy embedding method on a triangular lattice layout with 200 traps (`greedy_traps`). It also allows working on a square lattice layout, as well as increasing the number of traps according to the device specifications.
 
 ```python exec="on" source="material-block" html="1" session="embedding"
 from qoolqit import AnalogDevice
 
-embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=500, greedy_layout="triangular")
+embedconfig = EmbeddingConfig(embedding_method="greedy", greedy_traps=200, greedy_layout="triangular")
 greedy_config = SolverConfig(
     use_quantum=True,
     embedding=embedconfig,

--- a/docs/tutorial/04-qubo-embedding.ipynb
+++ b/docs/tutorial/04-qubo-embedding.ipynb
@@ -209,7 +209,7 @@
    "metadata": {},
    "source": [
     "### Greedy embedder parametrization\n",
-    "We do the same using the `greedy` embedding method, using a triangular lattice layout on a `DigitalAnalogDevice` with a number of greedy_traps at least equal to the number of variables in the QUBO:"
+    "We do the same using the `greedy` embedding method, using a triangular lattice layout on a `DigitalAnalogDevice` with a number of greedy_traps at least equal to the number of variables in the QUBO (with `-1` the number of traps is automatically set to the device capacity):"
    ]
   },
   {
@@ -230,7 +230,7 @@
     }
    ],
    "source": [
-    "greedy_settings = EmbeddingConfig(embedding_method=\"greedy\", greedy_layout=\"triangular\", greedy_traps=instance.size)\n",
+    "greedy_settings = EmbeddingConfig(embedding_method=\"greedy\", greedy_layout=\"triangular\", greedy_traps=-1)\n",
     "\n",
     "greedy_config = SolverConfig.from_kwargs(\n",
     "    use_quantum=True,\n",

--- a/qubosolver/algorithms/greedy/greedy.py
+++ b/qubosolver/algorithms/greedy/greedy.py
@@ -269,11 +269,10 @@ class Greedy:
                 _, u_coordinates, _ = typing.cast(Tuple[Any, Any, Any], res3)
                 candidates = []
 
-            x, y = torch.tensor(u_coordinates)  # might be negative
-            x_, y_ = torch.abs(x), torch.abs(y)
+            distance = torch.tensor(u_coordinates).norm().item()
 
             # check whether trap coordinate is within the maximal radial distance
-            if max_radial_distance and (x_ >= max_radial_distance or y_ >= max_radial_distance):
+            if max_radial_distance and (distance >= max_radial_distance):
                 if n_extra_traps == 0:
                     raise ValueError(
                         f"no traps found to place qubit '{u}' "

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -159,10 +159,8 @@ class EmbeddingConfig(Config):
         greedy_layout (LayoutType | str, optional): Layout type for the
             greedy embedder method. Defaults to `LayoutType.TRIANGULAR`.
         greedy_traps (int, optional): The number of traps on the register.
-            Defaults to ``1000``. A higher value improves embedding quality at the cost of
-            increased computation time.
-            Setting it too high may produce a register that exceeds the capacity of the
-            selected device.
+            Defaults to ``-1``, i.e. automatically set to match the selected device capacity.
+            A too high value will impede computational efficiency.
         greedy_spacing (float, optional): The minimum distance between atoms.
             Defaults to 7 (μm).
         greedy_density (float, optional): The estimated density of the QUBO matrix.
@@ -183,7 +181,7 @@ class EmbeddingConfig(Config):
 
     embedding_method: Any = EmbedderType.GREEDY
     greedy_layout: LayoutType | str = LayoutType.TRIANGULAR
-    greedy_traps: int = 1000
+    greedy_traps: int = -1
     greedy_spacing: float = 7.0
     greedy_density: float | None = None
     blade_steps_per_round: int | None = 200

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -9,7 +9,6 @@ import torch
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator, model_serializer
 
 from pulser_simulation import QutipBackendV2
-from pulser.devices import DigitalAnalogDevice as PulserDigitalAnalogDevice
 from qoolqit.devices.device import Device, DigitalAnalogDevice
 from qoolqit.execution import LocalEmulator, RemoteEmulator, QPU
 from pulser_pasqal import PasqalCloud
@@ -160,9 +159,12 @@ class EmbeddingConfig(Config):
         greedy_layout (LayoutType | str, optional): Layout type for the
             greedy embedder method. Defaults to `LayoutType.TRIANGULAR`.
         greedy_traps (int, optional): The number of traps on the register.
-            Defaults to `pulser.DigitalAnalogDevice.min_layout_traps`.
+            Defaults to ``1000``. A higher value improves embedding quality at the cost of
+            increased computation time.
+            Setting it too high may produce a register that exceeds the capacity of the
+            selected device.
         greedy_spacing (float, optional): The minimum distance between atoms.
-            Defaults to `pulser.PulserDigitalAnalogDevice.min_atom_distance`.
+            Defaults to 7 (μm).
         greedy_density (float, optional): The estimated density of the QUBO matrix.
             Defaults to None.
         blade_steps_per_round (int, optional): The number of steps
@@ -181,8 +183,8 @@ class EmbeddingConfig(Config):
 
     embedding_method: Any = EmbedderType.GREEDY
     greedy_layout: LayoutType | str = LayoutType.TRIANGULAR
-    greedy_traps: int = PulserDigitalAnalogDevice.min_layout_traps
-    greedy_spacing: float = float(PulserDigitalAnalogDevice.min_atom_distance)
+    greedy_traps: int = 1000
+    greedy_spacing: float = 7.0
     greedy_density: float | None = None
     blade_steps_per_round: int | None = 200
     blade_starting_positions: torch.Tensor | None = None
@@ -461,15 +463,10 @@ class SolverConfig(Config):
         print(self.specs())
 
     @model_validator(mode="after")
-    def _set_greedy_traps_greedy_spacing_from_device(self) -> SolverConfig:
+    def _set_greedy_spacing_from_device(self) -> SolverConfig:
 
         if self.device:
             device = self.device._device
-            if hasattr(device, "min_layout_traps"):
-                if self.embedding.greedy_traps < device.min_layout_traps:
-                    self.embedding = self.embedding.model_copy(
-                        update={"greedy_traps": device.min_layout_traps}
-                    )
             if hasattr(device, "min_atom_distance"):
                 greedy_spacing_device = float(device.min_atom_distance)
                 if self.embedding.greedy_spacing < greedy_spacing_device:

--- a/qubosolver/pipeline/basesolver.py
+++ b/qubosolver/pipeline/basesolver.py
@@ -38,11 +38,6 @@ class BaseSolver(ABC):
         else:
             self.config = config
 
-        if instance.size:
-            self.config.embedding.greedy_traps = max(
-                self.config.embedding.greedy_traps, instance.size
-            )
-
         self.backend = self.config.backend
         self.device = self.config.device
 

--- a/qubosolver/pipeline/embedder.py
+++ b/qubosolver/pipeline/embedder.py
@@ -7,6 +7,7 @@ import torch
 import warnings
 
 from qoolqit import Register as QoolqitRegister
+from qoolqit.devices import Device
 
 from qubosolver import QUBOInstance, concepts
 from qubosolver.algorithms.blade.blade import em_blade_for_device
@@ -118,6 +119,17 @@ class GreedyEmbedder(BaseEmbedder):
     interaction matrix U (approx. C / ||r_i - r_j||^6).
     """
 
+    @staticmethod
+    def _number_of_traps_from_device(device: Device) -> int:
+
+        if device._device.max_layout_traps:
+            return device._device.max_layout_traps
+
+        if device._device.max_atom_num:
+            return 2 * device._device.max_atom_num
+
+        return 200
+
     @typing.no_type_check
     def embed(self) -> QoolqitRegister:
         """
@@ -126,14 +138,14 @@ class GreedyEmbedder(BaseEmbedder):
         Returns:
             Register: The register.
         """
+        if self.config.embedding.greedy_traps == -1:
+            self.config.embedding.greedy_traps = self._number_of_traps_from_device(
+                self.config.device
+            )
+
         if self.config.embedding.greedy_traps < self.instance.size:
             raise ValueError(
                 "Number of traps must be at least equal to the number of atoms on the register."
-            )
-
-        if self.config.embedding.greedy_traps < 2 * self.instance.size:
-            warnings.warn(
-                f"GreedyEmbedder: Number of traps ({self.config.embedding.greedy_traps}) is less than twice the number of atoms ({self.instance.size}). You might want to increase the number of traps to get a better embedding."
             )
 
         # compute density (unchanged)

--- a/qubosolver/pipeline/embedder.py
+++ b/qubosolver/pipeline/embedder.py
@@ -126,7 +126,7 @@ class GreedyEmbedder(BaseEmbedder):
             return device._device.max_layout_traps
 
         if device._device.max_atom_num:
-            return 2 * device._device.max_atom_num
+            return int(device._device.max_atom_num / device._device.max_layout_filling)
 
         return 200
 

--- a/qubosolver/pipeline/embedder.py
+++ b/qubosolver/pipeline/embedder.py
@@ -36,6 +36,7 @@ class BaseEmbedder(ABC):
         self.register: QoolqitRegister | None = None
         self.backend = backend
 
+        # TODO: remove when bumping to qoolqit v1
         # for converting to qoolqit
         self._distance_conversion = self.config.device.converter.factors[2]
 

--- a/qubosolver/pipeline/embedder.py
+++ b/qubosolver/pipeline/embedder.py
@@ -121,12 +121,29 @@ class GreedyEmbedder(BaseEmbedder):
 
     @staticmethod
     def _number_of_traps_from_device(device: Device) -> int:
+        """Determine the number of traps to use based on the device constraints.
+
+        Inspects the device's layout and atom number limits to derive an
+        appropriate trap count. The resolution order is:
+
+        1. ``max_layout_traps`` – if the device exposes a hard trap limit, use it directly.
+        2. ``max_atom_num`` / ``max_layout_filling`` – if only an atom-number limit is
+           available, derive the minimum number of traps needed to accommodate that
+           many atoms at the device's maximum filling ratio.
+        3. Fallback – return ``200`` when neither property is set.
+
+        Args:
+            device (Device): The quantum device whose constraints are inspected.
+
+        Returns:
+            int: The number of traps to allocate for the embedding.
+        """
 
         if device._device.max_layout_traps:
             return device._device.max_layout_traps
 
         if device._device.max_atom_num:
-            return int(device._device.max_atom_num / device._device.max_layout_filling)
+            return int(np.ceil(device._device.max_atom_num / device._device.max_layout_filling))
 
         return 200
 

--- a/qubosolver/pipeline/embedder.py
+++ b/qubosolver/pipeline/embedder.py
@@ -130,6 +130,11 @@ class GreedyEmbedder(BaseEmbedder):
                 "Number of traps must be at least equal to the number of atoms on the register."
             )
 
+        if self.config.embedding.greedy_traps < 2 * self.instance.size:
+            warnings.warn(
+                f"GreedyEmbedder: Number of traps ({self.config.embedding.greedy_traps}) is less than twice the number of atoms ({self.instance.size}). You might want to increase the number of traps to get a better embedding."
+            )
+
         # compute density (unchanged)
         self.config.embedding.greedy_density = calculate_density(
             self.instance.coefficients, self.instance.size

--- a/tests/embeddings/test_embedding.py
+++ b/tests/embeddings/test_embedding.py
@@ -20,9 +20,7 @@ def test_embeddings_different_devices(
 ) -> None:
     config = SolverConfig(
         use_quantum=True,
-        embedding=EmbeddingConfig(
-            embedding_method=embedding_method, greedy_traps=qubo_for_testing_many_devices.size
-        ),
+        embedding=EmbeddingConfig(embedding_method=embedding_method, greedy_traps=500),
         do_postprocessing=False,
         do_preprocessing=False,
         device=local_device,
@@ -50,7 +48,9 @@ def test_correctness_greedy_embedder(qubo_instance_for_embedding: QUBOInstance) 
     config = SolverConfig(
         use_quantum=True,
         embedding=EmbeddingConfig(
-            embedding_method="greedy", greedy_traps=qubo_instance_for_embedding.size
+            embedding_method="greedy",
+            greedy_traps=qubo_instance_for_embedding.size,
+            greedy_spacing=4.0,
         ),
     )
     solver = QuboSolver(qubo_instance_for_embedding, config)

--- a/tests/embeddings/test_embedding.py
+++ b/tests/embeddings/test_embedding.py
@@ -20,7 +20,7 @@ def test_embeddings_different_devices(
 ) -> None:
     config = SolverConfig(
         use_quantum=True,
-        embedding=EmbeddingConfig(embedding_method=embedding_method, greedy_traps=500),
+        embedding=EmbeddingConfig(embedding_method=embedding_method, greedy_traps=-1),
         do_postprocessing=False,
         do_preprocessing=False,
         device=local_device,

--- a/tests/embeddings/test_greedy.py
+++ b/tests/embeddings/test_greedy.py
@@ -308,7 +308,7 @@ def test_max_distance_constraint() -> None:
     layout = LayoutType.SQUARE
     traps = 9
     assert isinstance(device.max_radial_distance, int)
-    spacing = device.max_radial_distance - 0.1
+    spacing = 0.99 * device.max_radial_distance
 
     dataset = QUBODataset.from_random(1, traps)
     Q, _ = dataset[0]

--- a/tests/embeddings/test_greedy.py
+++ b/tests/embeddings/test_greedy.py
@@ -7,6 +7,7 @@ from qoolqit.devices.device import DigitalAnalogDevice
 
 from qubosolver.algorithms.greedy.greedy import Greedy
 from qubosolver.qubo_types import LayoutType
+from qubosolver.data import QUBODataset
 import pytest
 import pytest_check as check
 
@@ -209,7 +210,7 @@ def test_too_large_spacing(too_large: str, relative_noise: float) -> None:
         spacing = device.max_radial_distance * 3.0
     # Only the inner square is within the device's maximum radial distance
     elif too_large == "barely":
-        spacing = device.max_radial_distance - 0.1
+        spacing = device.max_radial_distance / np.sqrt(2) - 0.1
     # All traps are within the device's maximum radial distance
     else:
         spacing = 7.0
@@ -295,3 +296,29 @@ def test_too_large_spacing(too_large: str, relative_noise: float) -> None:
             ]
         )
         assert_close_up_to_isometry(vertices, expected_imperfect_vertices, torch.pi / 2.0)
+
+
+def test_max_distance_constraint() -> None:
+
+    device = DigitalAnalogDevice()._device
+
+    # A square layout of size 9 is composed of a square of side 2*spacing, plus the origin.
+    # With a large enough spacing, the outer corners should be out of range, and thus a
+    # qubo of size 9 should not be embeddable.
+    layout = LayoutType.SQUARE
+    traps = 9
+    assert isinstance(device.max_radial_distance, int)
+    spacing = device.max_radial_distance - 0.1
+
+    dataset = QUBODataset.from_random(1, traps)
+    Q, _ = dataset[0]
+
+    parameters = {
+        "layout": layout,
+        "traps": traps,
+        "spacing": spacing,
+        "device": device,
+    }
+
+    with pytest.raises(ValueError):
+        Greedy().launch_greedy(Q=Q, params=parameters)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,13 +116,13 @@ def test_greedy_embedding_config(greedy_embedding_config: SolverConfig) -> None:
 def test_initialization_device() -> None:
 
     solver = SolverConfig()
-    assert solver.embedding.greedy_traps == 1000
+    assert solver.embedding.greedy_traps == -1
     assert solver.embedding.greedy_spacing == 7.0
 
     deviceanalog = AnalogDevice()
     kwargs: dict[Any, Any] = {"device": deviceanalog}
     solver = SolverConfig.from_kwargs(**kwargs)
-    assert solver.embedding.greedy_traps == 1000
+    assert solver.embedding.greedy_traps == -1
     assert solver.embedding.greedy_spacing == 7.0
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest_check as check
 from pulser.devices import DigitalAnalogDevice as PulserDADevice
 from pulser_simulation import QutipBackendV2
-from qoolqit.devices.device import DigitalAnalogDevice, AnalogDevice
+from qoolqit.devices.device import AnalogDevice
 from qubosolver.config import (
     LocalEmulator,
     ClassicalConfig,
@@ -116,15 +116,14 @@ def test_greedy_embedding_config(greedy_embedding_config: SolverConfig) -> None:
 def test_initialization_device() -> None:
 
     solver = SolverConfig()
-    device = DigitalAnalogDevice()
-    assert solver.embedding.greedy_traps == device._device.min_layout_traps
-    assert solver.embedding.greedy_spacing == float(device._device.min_atom_distance)
+    assert solver.embedding.greedy_traps == 1000
+    assert solver.embedding.greedy_spacing == 7.0
 
     deviceanalog = AnalogDevice()
     kwargs: dict[Any, Any] = {"device": deviceanalog}
     solver = SolverConfig.from_kwargs(**kwargs)
-    assert solver.embedding.greedy_traps == deviceanalog._device.min_layout_traps
-    assert solver.embedding.greedy_spacing == float(deviceanalog._device.min_atom_distance)
+    assert solver.embedding.greedy_traps == 1000
+    assert solver.embedding.greedy_spacing == 7.0
 
 
 def test_decomposition_config() -> None:

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -316,6 +316,10 @@ def test_quantum_prepostprocessing_2(
     config.backend = LocalEmulator(runs=50)
     solver = QuboSolver(instance, config)
 
+    from qoolqit.devices import DigitalAnalogDevice
+    # print(f"solver.device._device.max_layout_traps = {solver.device._device.max_layout_traps}")
+    print(f"solver.device._device.max_layout_traps = {DigitalAnalogDevice()._device.max_layout_traps}")
+
     solutions = solver.solve()
 
     analyzer = QUBOAnalyzer([solutions])

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -316,10 +316,6 @@ def test_quantum_prepostprocessing_2(
     config.backend = LocalEmulator(runs=50)
     solver = QuboSolver(instance, config)
 
-    from qoolqit.devices import DigitalAnalogDevice
-    # print(f"solver.device._device.max_layout_traps = {solver.device._device.max_layout_traps}")
-    print(f"solver.device._device.max_layout_traps = {DigitalAnalogDevice()._device.max_layout_traps}")
-
     solutions = solver.solve()
 
     analyzer = QUBOAnalyzer([solutions])


### PR DESCRIPTION
I tuned the spacing and the number of traps for the greedy algorithm.

### Spacing
I followed @yassine-naghmouchi recommandation

### Number of traps
At first I was considering a default value of `-1` that would mean an automatic (and implementation-defined) tuning of this parameter, depending on the device constraints and the size of the qubo. I decided against it, because it would probably introduce behavior changes across minor versions that could break users' code.  Instead I went for a high value of `1000` traps.

I might be wrong, but it seems to me that :

1. It's not really correlated to the max number of traps of the device. Once the greedy embedding is done, only N qubits remain where N is the size of the Qubo.
2. However, it's limited by the max distance of the device and the spacing. Two many traps will produce a large lattice, scaled by the spacing. This lattice can exceed the max distance.
3. It's also limited by computational time.

I decided : 
a. To take a high number of traps, with computational time that I deemed acceptable.
b. About point 2 above, to delegate the responsibility of the error to the compilation. I added a comment in the doc-string.

