### PR TITLE
Default mode should be quantum

### DIFF
--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -409,7 +409,7 @@ class SolverConfig(Config):
         config_name (str, optional): The name of the current configuration.
             Defaults to ''.
         use_quantum (bool, optional): Whether to solve using a quantum approach (`True`)
-            or a classical approach (`False`). Defaults to False.
+            or a classical approach (`False`). Defaults to True.
         embedding (EmbeddingConfig, optional): Embedding part configuration of the solver.
         drive_shaping (DriveShapingConfig, optional): Drive-shaping part configuration
             of the solver.

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -432,7 +432,7 @@ class SolverConfig(Config):
     """
 
     config_name: str = ""
-    use_quantum: bool | None = False
+    use_quantum: bool | None = True
     embedding: EmbeddingConfig = EmbeddingConfig()
     drive_shaping: DriveShapingConfig = DriveShapingConfig()
     classical: ClassicalConfig = ClassicalConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ from qubosolver.qubo_types import (
 
 def test_empty_config(empty_config: SolverConfig) -> None:
     assert empty_config.config_name == ""
-    assert empty_config.use_quantum is False
+    assert empty_config.use_quantum is True
     assert isinstance(empty_config.backend, LocalEmulator)
     assert empty_config.backend._backend_type == QutipBackendV2
     assert empty_config.embedding.embedding_method == EmbedderType.GREEDY


### PR DESCRIPTION
@abussy-pasqal Should we remove the `use_quantum` and enforce this behavior without letting the user the possibility of using the classical workflow?