### PR TITLE
[Feature] Automatic emulator selection based on qubit count

### DIFF
--- a/docs/content/backend.md
+++ b/docs/content/backend.md
@@ -14,42 +14,27 @@ The backend configuration part in `SolverConfig` is set via two fields.
 
 ## Local backends
 
-Local backends perform simulations locally. The main available backends are:
+Local backends perform simulations locally with automatic backend selection based on problem size. The `LocalEmulator` automatically chooses the most efficient backend:
 
-- `qutip` using the Qutip simulator as the default,
-- `emu_mps`: emulator based on state of the art tensor network techniques,
-- `emu_sv`: emulator based on state-vector description.
+- **QutipBackendV2**: using the Qutip simulator, for small problems (< 20 qubits),
+- **SVBackend**: emulator based on state-vector description, for medium problems (20-29 qubits),
+- **MPSBackend**: emulator based on state of the art tensor network techniques, for large problems (≥ 30 qubits).
 
-To use any, simply instantiate a `SolverConfig` with the `backend` attribute as a `LocalEmulator`.
-We can specify the number of shots via the runs attribute and configure differently the backend.
-See Qoolqit for more details.
+To use the automatic selection, simply instantiate a `SolverConfig` with a `LocalEmulator`:
 
 ```python exec="on" source="material-block"
-
 from qubosolver.config import SolverConfig, LocalEmulator
-from pulser_simulation import QutipBackendV2
-from emu_sv import SVBackend
-from emu_mps import MPSBackend
 from qoolqit import DigitalAnalogDevice
 
-locals_bkds = [
-    LocalEmulator(backend_type=btype, num_shots=500)
-    for btype in [
-        QutipBackendV2,
-        SVBackend,
-        MPSBackend,
-    ]
-]
-
-
+# Automatic backend selection based on problem size
 config = SolverConfig(
     use_quantum=True,
-    backend=locals_bkds[0],
+    backend=LocalEmulator(num_shots=500),
     device=DigitalAnalogDevice(),
 )
 ```
 
-Alternatively use the `SolverConfig.from_kwargs` method:
+You can also manually specify a particular backend type if needed:
 
 ```python exec="on" source="material-block"
 from qubosolver.config import SolverConfig, LocalEmulator
@@ -58,18 +43,16 @@ from emu_sv import SVBackend
 from emu_mps import MPSBackend
 from qoolqit import DigitalAnalogDevice
 
-locals_bkds = [
-    LocalEmulator(backend_type=btype, num_shots=500)
-    for btype in [
-        QutipBackendV2,
-        SVBackend,
-        MPSBackend,
-    ]
+# Manual backend selection
+manual_backends = [
+    LocalEmulator(backend_type=QutipBackendV2, num_shots=500),
+    LocalEmulator(backend_type=SVBackend, num_shots=500),
+    LocalEmulator(backend_type=MPSBackend, num_shots=500),
 ]
 
-config = SolverConfig.from_kwargs(
+config = SolverConfig(
     use_quantum=True,
-    backend=locals_bkds[0],
+    backend=manual_backends[0],  # Use QutipBackendV2
     device=DigitalAnalogDevice(),
 )
 ```
@@ -129,5 +112,7 @@ if PASSWORD is not None:
         use_quantum=True,
         backend = QPU(connection=connection, num_shots=500), device=device,
     )
+
+```
 
 ```

--- a/docs/content/backend.md
+++ b/docs/content/backend.md
@@ -16,9 +16,9 @@ The backend configuration part in `SolverConfig` is set via two fields.
 
 Local backends perform simulations locally with automatic backend selection based on problem size. The `LocalEmulator` automatically chooses the most efficient backend:
 
-- **QutipBackendV2**: using the Qutip simulator, for small problems (< 20 qubits),
-- **SVBackend**: emulator based on state-vector description, for medium problems (20-29 qubits),
-- **MPSBackend**: emulator based on state of the art tensor network techniques, for large problems (≥ 30 qubits).
+- **QutipBackendV2**: using the Qutip simulator, for small problems (< 15 qubits),
+- **SVBackend**: emulator based on state-vector description, for medium problems (15-25 qubits),
+- **MPSBackend**: emulator based on state of the art tensor network techniques, for large problems (≥ 26 qubits).
 
 To use the automatic selection, simply instantiate a `SolverConfig` with a `LocalEmulator`:
 

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -24,6 +24,5 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
 
 
 class LocalEmulator(_LocalEmulator):
-    def __init__(self, **kwargs):
-        kwargs.setdefault("backend_type", _AutoLocalEmulatorBackend)
-        super().__init__(**kwargs)
+    def __init__(self, backend_type=_AutoLocalEmulatorBackend, **kwargs):
+        super().__init__(backend_type=backend_type, **kwargs)

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -31,7 +31,7 @@ _MPS_THRESHOLD = 26  # Use MPS-based backends for problems with ≥26 qubits
 _SV_THRESHOLD = 15  # Use state-vector backends for problems with ≥15 qubits
 
 
-def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
+def _select_backend_type(n_qubits: int) -> Type[EmulatorBackend]:
     """Select the optimal backend class based on the number of qubits.
 
     Args:
@@ -44,10 +44,10 @@ def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
     # relationship in case the third-party library changes.
     # nosec B101: Bandit flags assert usage as it can be stripped with -O,
     # but here it's a deliberate invariant check, not input validation.
-    if n_quibts >= _MPS_THRESHOLD:
+    if n_qubits >= _MPS_THRESHOLD:
         assert issubclass(MPSBackend, EmulatorBackend)  # nosec B101
         return cast(Type[EmulatorBackend], MPSBackend)
-    elif n_quibts >= _SV_THRESHOLD:
+    elif n_qubits >= _SV_THRESHOLD:
         assert issubclass(SVBackend, EmulatorBackend)  # nosec B101
         return cast(Type[EmulatorBackend], SVBackend)
     else:

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -5,11 +5,12 @@ from pulser.backend.abc import EmulatorBackend
 from pulser_simulation import QutipBackendV2
 from emu_sv import SVBackend
 from emu_mps import MPSBackend
+from qoolqit.execution import LocalEmulator as _LocalEmulator
 
 _MPS_THRESHOLD = 30
 _SV_THRESHOLD = 20
 
-class AutoLocalEmulatorBackend(EmulatorBackend):
+class _AutoLocalEmulatorBackend(EmulatorBackend):
     def __new__(cls, sequence: PulserSequence, *args, **kwargs):
         n_qubits = len(sequence.register.qubit_ids)
         if n_qubits >= _MPS_THRESHOLD:
@@ -20,3 +21,9 @@ class AutoLocalEmulatorBackend(EmulatorBackend):
             backend = super().__new__(QutipBackendV2)
         backend.__init__(sequence, *args, **kwargs)
         return backend
+
+
+class LocalEmulator(_LocalEmulator):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("backend_type", _AutoLocalEmulatorBackend)
+        super().__init__(**kwargs)

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -44,16 +44,14 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
         EmulatorBackend: The selected backend instance.
     """
 
-    def __new__(cls, sequence: PulserSequence, *args, **kwargs):
+    def __new__(cls, sequence: PulserSequence, *args: Any, **kwargs: Any) -> EmulatorBackend:
         n_qubits = len(sequence.register.qubit_ids)
         if n_qubits >= _MPS_THRESHOLD:
-            backend = super().__new__(MPSBackend)
+            return MPSBackend(sequence, *args, **kwargs)
         elif n_qubits >= _SV_THRESHOLD:
-            backend = super().__new__(SVBackend)
+            return SVBackend(sequence, *args, **kwargs)
         else:
-            backend = super().__new__(QutipBackendV2)
-        backend.__init__(sequence, *args, **kwargs)
-        return backend
+            return QutipBackendV2(sequence, *args, **kwargs)
 
 
 class LocalEmulator(QoolqitLocalEmulator):
@@ -75,5 +73,7 @@ class LocalEmulator(QoolqitLocalEmulator):
         >>> # Backend will be automatically selected based on problem size
     """
 
-    def __init__(self, backend_type=_AutoLocalEmulatorBackend, **kwargs):
+    def __init__(
+        self, backend_type: Type[EmulatorBackend] = _AutoLocalEmulatorBackend, **kwargs: Any
+    ) -> None:
         super().__init__(backend_type=backend_type, **kwargs)

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -27,7 +27,14 @@ _SV_THRESHOLD = 20  # Use state-vector backends for problems with ≥20 qubits
 
 
 def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
-    """Select the most efficient local backend based on the number of qubits."""
+    """Select the optimal backend class based on the number of qubits.
+
+    Args:
+        n_qubits (int): Number of qubits in the quantum register.
+
+    Returns:
+        Type[EmulatorBackend]: The selected backend class optimized for the given size.
+    """
     if n_quibts >= _MPS_THRESHOLD:
         assert issubclass(MPSBackend, EmulatorBackend)
         return cast(Type[EmulatorBackend], MPSBackend)
@@ -39,24 +46,29 @@ def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
 
 
 class _AutoLocalEmulatorBackend(EmulatorBackend):
-    """Factory that selects a local emulator backend based on register size.
+    """Factory class that automatically selects optimal emulator backends.
 
-    This factory automatically chooses the most efficient local backend:
+    This factory uses __new__ to return instances of different backend types
+    based on quantum register size for optimal performance:
     - MPSBackend for large problems (≥30 qubits)
     - SVBackend for medium problems (20-29 qubits)
     - QutipBackendV2 for small problems (<20 qubits)
 
-    Uses __new__ instead of a plain factory function because
-    qoolqit.LocalEmulator requires backend_type to pass an
-    issubclass(backend_type, EmulatorBackend) check.
+    Note: This class acts as a factory and never instantiates itself.
+    The __new__ method directly returns instances of the selected backend type.
+    Type checking is suppressed as this factory pattern confuses static analyzers.
+
+    Required by qoolqit.LocalEmulator which expects backend_type to pass
+    issubclass(backend_type, EmulatorBackend) checks.
 
     Args:
         sequence (PulserSequence): The pulse sequence to simulate.
-        *args: Additional positional arguments passed to the backend.
-        **kwargs: Additional keyword arguments passed to the backend.
+        *args: Additional positional arguments passed to the selected backend.
+        **kwargs: Additional keyword arguments passed to the selected backend.
 
     Returns:
-        EmulatorBackend: The selected backend instance.
+        EmulatorBackend: An instance of the automatically selected backend
+        (MPSBackend, SVBackend, or QutipBackendV2).
     """
 
     def __new__(cls, sequence: PulserSequence, *args: Any, **kwargs: Any) -> EmulatorBackend:  # type: ignore[misc]

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -40,11 +40,15 @@ def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
     Returns:
         Type[EmulatorBackend]: The selected backend class optimized for the given size.
     """
+    # Runtime guard: cast() is unchecked by mypy, so we verify the subclass
+    # relationship in case the third-party library changes.
+    # nosec B101: Bandit flags assert usage as it can be stripped with -O,
+    # but here it's a deliberate invariant check, not input validation.
     if n_quibts >= _MPS_THRESHOLD:
-        assert issubclass(MPSBackend, EmulatorBackend)
+        assert issubclass(MPSBackend, EmulatorBackend)  # nosec B101
         return cast(Type[EmulatorBackend], MPSBackend)
     elif n_quibts >= _SV_THRESHOLD:
-        assert issubclass(SVBackend, EmulatorBackend)
+        assert issubclass(SVBackend, EmulatorBackend)  # nosec B101
         return cast(Type[EmulatorBackend], SVBackend)
     else:
         return QutipBackendV2

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -5,9 +5,9 @@ selects the optimal backend implementation based on the quantum register size.
 
 The automatic selection optimizes performance by choosing backends that are
 most efficient for the given problem size:
-- Small problems (< 20 qubits): QutipBackendV2
-- Medium problems (20-29 qubits): SVBackend
-- Large problems (≥ 30 qubits): MPSBackend
+- Small problems (< 15 qubits): QutipBackendV2
+- Medium problems (15-25 qubits): SVBackend
+- Large problems (≥ 26 qubits): MPSBackend
 
 References:
 - SVBackend performance benchmarks: https://pasqal-io.github.io/emulators/latest/emu_sv/benchmarks/performance/
@@ -27,8 +27,8 @@ from emu_mps import MPSBackend
 from qoolqit.execution import LocalEmulator as QoolqitLocalEmulator
 
 # Thresholds for automatic backend selection based on number of qubits
-_MPS_THRESHOLD = 30  # Use MPS-based backends for problems with ≥30 qubits
-_SV_THRESHOLD = 20  # Use state-vector backends for problems with ≥20 qubits
+_MPS_THRESHOLD = 26  # Use MPS-based backends for problems with ≥26 qubits
+_SV_THRESHOLD = 15  # Use state-vector backends for problems with ≥15 qubits
 
 
 def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
@@ -55,9 +55,9 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
 
     This factory uses __new__ to return instances of different backend types
     based on quantum register size for optimal performance:
-    - MPSBackend for large problems (≥30 qubits)
-    - SVBackend for medium problems (20-29 qubits)
-    - QutipBackendV2 for small problems (<20 qubits)
+    - MPSBackend for large problems (≥26 qubits)
+    - SVBackend for medium problems (15-25 qubits)
+    - QutipBackendV2 for small problems (<15 qubits)
 
     Note: This class acts as a factory and never instantiates itself.
     The __new__ method directly returns instances of the selected backend type.

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -5,7 +5,7 @@ from pulser.backend.abc import EmulatorBackend
 from pulser_simulation import QutipBackendV2
 from emu_sv import SVBackend
 from emu_mps import MPSBackend
-from qoolqit.execution import LocalEmulator as _LocalEmulator
+from qoolqit.execution import LocalEmulator as QoolqitLocalEmulator
 
 _MPS_THRESHOLD = 30
 _SV_THRESHOLD = 20
@@ -30,6 +30,7 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
         return backend
 
 
-class LocalEmulator(_LocalEmulator):
+class LocalEmulator(QoolqitLocalEmulator):
+
     def __init__(self, backend_type=_AutoLocalEmulatorBackend, **kwargs):
         super().__init__(backend_type=backend_type, **kwargs)

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -12,6 +12,8 @@ most efficient for the given problem size:
 
 from __future__ import annotations
 
+from typing import Any, Type, cast
+
 from pulser import Sequence as PulserSequence
 from pulser.backend.abc import EmulatorBackend
 from pulser_simulation import QutipBackendV2
@@ -21,7 +23,20 @@ from qoolqit.execution import LocalEmulator as QoolqitLocalEmulator
 
 # Thresholds for automatic backend selection based on number of qubits
 _MPS_THRESHOLD = 30  # Use MPS-based backends for problems with ≥30 qubits
-_SV_THRESHOLD = 20   # Use state-vector backends for problems with ≥20 qubits
+_SV_THRESHOLD = 20  # Use state-vector backends for problems with ≥20 qubits
+
+
+def _select_backend_type(n_quibts: int) -> Type[EmulatorBackend]:
+    """Select the most efficient local backend based on the number of qubits."""
+    if n_quibts >= _MPS_THRESHOLD:
+        assert issubclass(MPSBackend, EmulatorBackend)
+        return cast(Type[EmulatorBackend], MPSBackend)
+    elif n_quibts >= _SV_THRESHOLD:
+        assert issubclass(SVBackend, EmulatorBackend)
+        return cast(Type[EmulatorBackend], SVBackend)
+    else:
+        return QutipBackendV2
+
 
 class _AutoLocalEmulatorBackend(EmulatorBackend):
     """Factory that selects a local emulator backend based on register size.
@@ -44,14 +59,9 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
         EmulatorBackend: The selected backend instance.
     """
 
-    def __new__(cls, sequence: PulserSequence, *args: Any, **kwargs: Any) -> EmulatorBackend:
+    def __new__(cls, sequence: PulserSequence, *args: Any, **kwargs: Any) -> EmulatorBackend:  # type: ignore[misc]
         n_qubits = len(sequence.register.qubit_ids)
-        if n_qubits >= _MPS_THRESHOLD:
-            return MPSBackend(sequence, *args, **kwargs)
-        elif n_qubits >= _SV_THRESHOLD:
-            return SVBackend(sequence, *args, **kwargs)
-        else:
-            return QutipBackendV2(sequence, *args, **kwargs)
+        return _select_backend_type(n_qubits)(sequence, *args, **kwargs)
 
 
 class LocalEmulator(QoolqitLocalEmulator):

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -11,6 +11,13 @@ _MPS_THRESHOLD = 30
 _SV_THRESHOLD = 20
 
 class _AutoLocalEmulatorBackend(EmulatorBackend):
+    """Factory that selects a backend based on register size.
+
+    Uses __new__ instead of a plain factory function because
+    qoolqit.LocalEmulator requires backend_type to pass an
+    issubclass(backend_type, EmulatorBackend) check.
+    """
+
     def __new__(cls, sequence: PulserSequence, *args, **kwargs):
         n_qubits = len(sequence.register.qubit_ids)
         if n_qubits >= _MPS_THRESHOLD:

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -1,3 +1,15 @@
+"""Local quantum backend implementation with automatic backend selection.
+
+This module provides a wrapper class for local quantum emulators that automatically
+selects the optimal backend implementation based on the quantum register size.
+
+The automatic selection optimizes performance by choosing backends that are
+most efficient for the given problem size:
+- Small problems (< 20 qubits): QutipBackendV2
+- Medium problems (20-29 qubits): SVBackend
+- Large problems (≥ 30 qubits): MPSBackend
+"""
+
 from __future__ import annotations
 
 from pulser import Sequence as PulserSequence
@@ -7,15 +19,29 @@ from emu_sv import SVBackend
 from emu_mps import MPSBackend
 from qoolqit.execution import LocalEmulator as QoolqitLocalEmulator
 
-_MPS_THRESHOLD = 30
-_SV_THRESHOLD = 20
+# Thresholds for automatic backend selection based on number of qubits
+_MPS_THRESHOLD = 30  # Use MPS-based backends for problems with ≥30 qubits
+_SV_THRESHOLD = 20   # Use state-vector backends for problems with ≥20 qubits
 
 class _AutoLocalEmulatorBackend(EmulatorBackend):
-    """Factory that selects a backend based on register size.
+    """Factory that selects a local emulator backend based on register size.
+
+    This factory automatically chooses the most efficient local backend:
+    - MPSBackend for large problems (≥30 qubits)
+    - SVBackend for medium problems (20-29 qubits)
+    - QutipBackendV2 for small problems (<20 qubits)
 
     Uses __new__ instead of a plain factory function because
     qoolqit.LocalEmulator requires backend_type to pass an
     issubclass(backend_type, EmulatorBackend) check.
+
+    Args:
+        sequence (PulserSequence): The pulse sequence to simulate.
+        *args: Additional positional arguments passed to the backend.
+        **kwargs: Additional keyword arguments passed to the backend.
+
+    Returns:
+        EmulatorBackend: The selected backend instance.
     """
 
     def __new__(cls, sequence: PulserSequence, *args, **kwargs):
@@ -31,6 +57,23 @@ class _AutoLocalEmulatorBackend(EmulatorBackend):
 
 
 class LocalEmulator(QoolqitLocalEmulator):
+    """Local quantum emulator with automatic backend selection.
+
+    This class wraps qoolqit.LocalEmulator and automatically selects
+    the optimal local backend based on the quantum register size.
+    It provides the same interface as the base LocalEmulator but with
+    improved performance through intelligent backend selection.
+
+    Args:
+        backend_type (type, optional): Backend type to use. Defaults to
+            _AutoLocalEmulatorBackend for automatic selection.
+        **kwargs: Additional keyword arguments passed to the base LocalEmulator.
+
+    Example:
+        >>> from qubosolver.backends import LocalEmulator
+        >>> emulator = LocalEmulator(num_shots=1000)
+        >>> # Backend will be automatically selected based on problem size
+    """
 
     def __init__(self, backend_type=_AutoLocalEmulatorBackend, **kwargs):
         super().__init__(backend_type=backend_type, **kwargs)

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pulser import Sequence as PulserSequence
+from pulser.backend.abc import EmulatorBackend
+from pulser_simulation import QutipBackendV2
+from emu_sv import SVBackend
+from emu_mps import MPSBackend
+
+_MPS_THRESHOLD = 30
+_SV_THRESHOLD = 20
+
+class AutoLocalEmulatorBackend(EmulatorBackend):
+    def __new__(cls, sequence: PulserSequence, *args, **kwargs):
+        n_qubits = len(sequence.register.qubit_ids)
+        if n_qubits >= _MPS_THRESHOLD:
+            backend = super().__new__(MPSBackend)
+        elif n_qubits >= _SV_THRESHOLD:
+            backend = super().__new__(SVBackend)
+        else:
+            backend = super().__new__(QutipBackendV2)
+        backend.__init__(sequence, *args, **kwargs)
+        return backend

--- a/qubosolver/backends.py
+++ b/qubosolver/backends.py
@@ -8,6 +8,11 @@ most efficient for the given problem size:
 - Small problems (< 20 qubits): QutipBackendV2
 - Medium problems (20-29 qubits): SVBackend
 - Large problems (≥ 30 qubits): MPSBackend
+
+References:
+- SVBackend performance benchmarks: https://pasqal-io.github.io/emulators/latest/emu_sv/benchmarks/performance/
+- MPSBackend performance benchmarks: https://pasqal-io.github.io/emulators/latest/emu_mps/benchmarks/
+- Backend selection methodology: https://arxiv.org/pdf/2510.09813
 """
 
 from __future__ import annotations

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -409,7 +409,7 @@ class SolverConfig(Config):
         config_name (str, optional): The name of the current configuration.
             Defaults to ''.
         use_quantum (bool, optional): Whether to solve using a quantum approach (`True`)
-            or a classical approach (`False`). Defaults to False.
+            or a classical approach (`False`). Defaults to True.
         embedding (EmbeddingConfig, optional): Embedding part configuration of the solver.
         drive_shaping (DriveShapingConfig, optional): Drive-shaping part configuration
             of the solver.

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator, mo
 
 from pulser_simulation import QutipBackendV2
 from qoolqit.devices.device import Device, DigitalAnalogDevice
-from qoolqit.execution import LocalEmulator, RemoteEmulator, QPU
+from qoolqit.execution import RemoteEmulator, QPU
 from qoolqit.execution.compilation_functions import CompilerProfile
 from pulser_pasqal import PasqalCloud
 
@@ -20,6 +20,7 @@ from qubosolver.qubo_types import (
     DriveType,
     ClassicalSolverType,
 )
+from qubosolver.backends import LocalEmulator
 
 # Allow torch.Tensor fields in Pydantic models.
 BaseModel.model_config["arbitrary_types_allowed"] = True

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -432,7 +432,7 @@ class SolverConfig(Config):
     """
 
     config_name: str = ""
-    use_quantum: bool | None = False
+    use_quantum: bool | None = True
     embedding: EmbeddingConfig = EmbeddingConfig()
     drive_shaping: DriveShapingConfig = DriveShapingConfig()
     classical: ClassicalConfig = ClassicalConfig()

--- a/tests/drive_shaping/test_optimized.py
+++ b/tests/drive_shaping/test_optimized.py
@@ -12,11 +12,10 @@ from typing import List, Iterable, Dict, Any
 
 from qoolqit.devices.device import DigitalAnalogDevice, AnalogDevice
 from qoolqit.register import Register
-from qoolqit.execution import LocalEmulator
 
 from qubosolver.pipeline.drive import OptimizedDriveShaper
 from qubosolver.qubo_instance import QUBOInstance
-from qubosolver.config import SolverConfig, DriveShapingConfig
+from qubosolver.config import SolverConfig, DriveShapingConfig, LocalEmulator
 from qubosolver.qubo_analyzer import QUBOAnalyzer
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -58,7 +58,7 @@ def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None
         use_quantum=True,
         backend=QoolqitLocalEmulator(backend_type=_AutoLocalEmulatorBackend),
         activate_trivial_solutions=False,
-        embedding=EmbeddingConfig(min_distance=1.001),
+        embedding=EmbeddingConfig(embedding_method="blade", min_distance=1.001),
     )
 
     solver = QuboSolver(instance, config)
@@ -80,7 +80,7 @@ def test_auto_local_emulator_run(size: int, expected_type: type) -> None:
         use_quantum=True,
         backend=LocalEmulator(),
         activate_trivial_solutions=False,
-        embedding=EmbeddingConfig(min_distance=1.001),
+        embedding=EmbeddingConfig(embedding_method="blade", min_distance=1.001),
     )
 
     solver = QuboSolver(instance, config)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -46,7 +46,7 @@ def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
 
     device = qoolqit.MockDevice()
     sequence = make_sequence(dummy_pulser_register(size), device)
-    backend = _AutoLocalEmulatorBackend(sequence)
+    backend = _AutoLocalEmulatorBackend(sequence)  # type: ignore[abstract]
     check.is_instance(backend, expected_type)
 
 
@@ -64,7 +64,7 @@ def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None
     instance = QUBOInstance(Q)
     config = SolverConfig(
         use_quantum=True,
-        backend=QoolqitLocalEmulator(backend_type=_AutoLocalEmulatorBackend),
+        backend=QoolqitLocalEmulator(backend_type=_AutoLocalEmulatorBackend),  # type: ignore[type-abstract]
         activate_trivial_solutions=False,
         embedding=EmbeddingConfig(embedding_method="blade", min_distance=1.001),
     )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from unittest.mock import patch, MagicMock
 
+import pytest
 import pytest_check as check
 import torch
 
@@ -13,7 +14,7 @@ from emu_mps import MPSBackend
 import qoolqit
 
 from qubosolver import QUBOInstance, SolverConfig, LocalEmulator, EmbeddingConfig
-from qubosolver.backends import AutoLocalEmulatorBackend
+from qubosolver.backends import _AutoLocalEmulatorBackend
 from qubosolver.solver import QuboSolver
 
 
@@ -26,39 +27,40 @@ def make_sequence(register: pulser.Register, device: qoolqit.Device) -> pulser.S
     )
     return sequence
 
-def test_auto_local_emulator_backend() -> None:
+def dummy_pulser_register(n: int) -> pulser.Register:
+    qubits = { f"q{i}": (float(i), 0.) for i in range(n) }
+    return pulser.Register(qubits)
 
-    def dummy_pulser_register(size: int) -> pulser.Register:
-        qubits = { f"q{i}": (float(i), 0.) for i in range(size) }
-        return pulser.Register(qubits)
+@pytest.mark.parametrize("size, expected_type", [
+    (15, QutipBackendV2),
+    (25, SVBackend),
+    (35, MPSBackend),
+])
+def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
 
     device = qoolqit.MockDevice()
-
-    backend_15 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(15), device))
-    check.is_instance(backend_15, QutipBackendV2)
-
-    backend_25 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(25), device))
-    check.is_instance(backend_25, SVBackend)
-
-    backend_35 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(35), device))
-    check.is_instance(backend_35, MPSBackend)
+    sequence = make_sequence(dummy_pulser_register(size), device)
+    backend = _AutoLocalEmulatorBackend(sequence)
+    check.is_instance(backend, expected_type)
 
 
-def test_auto_local_emulator_backend_run() -> None:
+@pytest.mark.parametrize("size, expected_type", [
+    (2, QutipBackendV2),
+    (25, SVBackend),
+    (35, MPSBackend),
+])
+def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None:
 
-    Q = torch.Tensor([[-1, 2], [2, -1]])
+    Q = torch.ones(size, size) + torch.diag(torch.full((size,), -3.0))
     instance = QUBOInstance(Q)
     config = SolverConfig(
         use_quantum=True,
-        backend=LocalEmulator(backend_type=AutoLocalEmulatorBackend),
+        backend=LocalEmulator(backend_type=_AutoLocalEmulatorBackend),
         activate_trivial_solutions=False,
         embedding=EmbeddingConfig(min_distance=1.001),
     )
 
     solver = QuboSolver(instance, config)
-    with patch.object(QutipBackendV2, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
+    with patch.object(expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
         solver.solve()
         mock_run.assert_called_once()
-
-
-

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -13,8 +13,9 @@ from emu_mps import MPSBackend
 
 import qoolqit
 
-from qubosolver import QUBOInstance, SolverConfig, LocalEmulator, EmbeddingConfig
-from qubosolver.backends import _AutoLocalEmulatorBackend
+from qubosolver import QUBOInstance, SolverConfig, EmbeddingConfig
+from qubosolver import LocalEmulator as QoolqitLocalEmulator
+from qubosolver.backends import _AutoLocalEmulatorBackend, LocalEmulator
 from qubosolver.solver import QuboSolver
 
 
@@ -55,7 +56,29 @@ def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None
     instance = QUBOInstance(Q)
     config = SolverConfig(
         use_quantum=True,
-        backend=LocalEmulator(backend_type=_AutoLocalEmulatorBackend),
+        backend=QoolqitLocalEmulator(backend_type=_AutoLocalEmulatorBackend),
+        activate_trivial_solutions=False,
+        embedding=EmbeddingConfig(min_distance=1.001),
+    )
+
+    solver = QuboSolver(instance, config)
+    with patch.object(expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
+        solver.solve()
+        mock_run.assert_called_once()
+
+
+@pytest.mark.parametrize("size, expected_type", [
+    (2, QutipBackendV2),
+    (25, SVBackend),
+    (35, MPSBackend),
+])
+def test_auto_local_emulator_run(size: int, expected_type: type) -> None:
+
+    Q = torch.ones(size, size) + torch.diag(torch.full((size,), -3.0))
+    instance = QUBOInstance(Q)
+    config = SolverConfig(
+        use_quantum=True,
+        backend=LocalEmulator(),
         activate_trivial_solutions=False,
         embedding=EmbeddingConfig(min_distance=1.001),
     )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -37,9 +37,9 @@ def dummy_pulser_register(n: int) -> pulser.Register:
 @pytest.mark.parametrize(
     "size, expected_type",
     [
-        (15, QutipBackendV2),
-        (25, SVBackend),
-        (35, MPSBackend),
+        (10, QutipBackendV2),
+        (20, SVBackend),
+        (30, MPSBackend),
     ],
 )
 def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
@@ -54,8 +54,8 @@ def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
     "size, expected_type",
     [
         (2, QutipBackendV2),
-        (25, SVBackend),
-        (35, MPSBackend),
+        (20, SVBackend),
+        (30, MPSBackend),
     ],
 )
 def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None:
@@ -81,8 +81,8 @@ def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None
     "size, expected_type",
     [
         (2, QutipBackendV2),
-        (25, SVBackend),
-        (35, MPSBackend),
+        (20, SVBackend),
+        (30, MPSBackend),
     ],
 )
 def test_auto_local_emulator_run(size: int, expected_type: type) -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -28,15 +28,20 @@ def make_sequence(register: pulser.Register, device: qoolqit.Device) -> pulser.S
     )
     return sequence
 
+
 def dummy_pulser_register(n: int) -> pulser.Register:
-    qubits = { f"q{i}": (float(i), 0.) for i in range(n) }
+    qubits = {f"q{i}": (float(i), 0.0) for i in range(n)}
     return pulser.Register(qubits)
 
-@pytest.mark.parametrize("size, expected_type", [
-    (15, QutipBackendV2),
-    (25, SVBackend),
-    (35, MPSBackend),
-])
+
+@pytest.mark.parametrize(
+    "size, expected_type",
+    [
+        (15, QutipBackendV2),
+        (25, SVBackend),
+        (35, MPSBackend),
+    ],
+)
 def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
 
     device = qoolqit.MockDevice()
@@ -45,11 +50,14 @@ def test_auto_local_emulator_backend(size: int, expected_type: type) -> None:
     check.is_instance(backend, expected_type)
 
 
-@pytest.mark.parametrize("size, expected_type", [
-    (2, QutipBackendV2),
-    (25, SVBackend),
-    (35, MPSBackend),
-])
+@pytest.mark.parametrize(
+    "size, expected_type",
+    [
+        (2, QutipBackendV2),
+        (25, SVBackend),
+        (35, MPSBackend),
+    ],
+)
 def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None:
 
     Q = torch.ones(size, size) + torch.diag(torch.full((size,), -3.0))
@@ -62,16 +70,21 @@ def test_auto_local_emulator_backend_run(size: int, expected_type: type) -> None
     )
 
     solver = QuboSolver(instance, config)
-    with patch.object(expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
+    with patch.object(
+        expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)
+    ) as mock_run:
         solver.solve()
         mock_run.assert_called_once()
 
 
-@pytest.mark.parametrize("size, expected_type", [
-    (2, QutipBackendV2),
-    (25, SVBackend),
-    (35, MPSBackend),
-])
+@pytest.mark.parametrize(
+    "size, expected_type",
+    [
+        (2, QutipBackendV2),
+        (25, SVBackend),
+        (35, MPSBackend),
+    ],
+)
 def test_auto_local_emulator_run(size: int, expected_type: type) -> None:
 
     Q = torch.ones(size, size) + torch.diag(torch.full((size,), -3.0))
@@ -84,6 +97,8 @@ def test_auto_local_emulator_run(size: int, expected_type: type) -> None:
     )
 
     solver = QuboSolver(instance, config)
-    with patch.object(expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
+    with patch.object(
+        expected_type, "run", return_value=MagicMock(spec=pulser.backend.Results)
+    ) as mock_run:
         solver.solve()
         mock_run.assert_called_once()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from unittest.mock import patch, MagicMock
+
+import pytest_check as check
+import torch
+
+
+import pulser
+from pulser_simulation import QutipBackendV2
+from emu_sv import SVBackend
+from emu_mps import MPSBackend
+
+import qoolqit
+
+from qubosolver import QUBOInstance, SolverConfig, LocalEmulator, EmbeddingConfig
+from qubosolver.backends import AutoLocalEmulatorBackend
+from qubosolver.solver import QuboSolver
+
+
+def make_sequence(register: pulser.Register, device: qoolqit.Device) -> pulser.Sequence:
+    sequence = pulser.Sequence(register, device._device)
+    sequence.declare_channel("rydberg", "rydberg_global")
+    sequence.add(
+        pulser.Pulse.ConstantPulse(200, 1.0, 0.0, 0.0),
+        "rydberg",
+    )
+    return sequence
+
+def test_auto_local_emulator_backend() -> None:
+
+    def dummy_pulser_register(size: int) -> pulser.Register:
+        qubits = { f"q{i}": (float(i), 0.) for i in range(size) }
+        return pulser.Register(qubits)
+
+    device = qoolqit.MockDevice()
+
+    backend_15 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(15), device))
+    check.is_instance(backend_15, QutipBackendV2)
+
+    backend_25 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(25), device))
+    check.is_instance(backend_25, SVBackend)
+
+    backend_35 = AutoLocalEmulatorBackend(make_sequence(dummy_pulser_register(35), device))
+    check.is_instance(backend_35, MPSBackend)
+
+
+def test_auto_local_emulator_backend_run() -> None:
+
+    Q = torch.Tensor([[-1, 2], [2, -1]])
+    instance = QUBOInstance(Q)
+    config = SolverConfig(
+        use_quantum=True,
+        backend=LocalEmulator(backend_type=AutoLocalEmulatorBackend),
+        activate_trivial_solutions=False,
+        embedding=EmbeddingConfig(min_distance=1.001),
+    )
+
+    solver = QuboSolver(instance, config)
+    with patch.object(QutipBackendV2, "run", return_value=MagicMock(spec=pulser.backend.Results)) as mock_run:
+        solver.solve()
+        mock_run.assert_called_once()
+
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ from qubosolver.qubo_types import (
 
 def test_empty_config(empty_config: SolverConfig) -> None:
     assert empty_config.config_name == ""
-    assert empty_config.use_quantum is False
+    assert empty_config.use_quantum is True
     assert isinstance(empty_config.backend, LocalEmulator)
     assert empty_config.backend._backend_type == QutipBackendV2
     assert empty_config.embedding.embedding_method == EmbedderType.GREEDY


### PR DESCRIPTION
[Feature] Automatic emulator selection based on qubit count

Add intelligent backend selection that automatically chooses the optimal emulator
based on quantum register size for improved performance:

- QutipBackendV2: Small problems (<15 qubits)
- SVBackend: Medium problems (15-25 qubits)
- MPSBackend: Large problems (>35 qubits)

Features:
- LocalEmulator wrapper with automatic selection as default
- Maintains compatibility with qoolqit.LocalEmulator interface

Note:
This automatic selection is designed specifically for local emulators where
performance is the primary concern. Remote emulators involve pricing considerations
and different cost models, so manual backend selection may be more appropriate.