### PR TITLE
[Security] Remove polyfill.io from MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,5 @@ extra_css:
 # For mathjax
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML


### PR DESCRIPTION
Recommended in old mkdocs.yml config but now is useless and not safe.

Impact:
* High security risk: Malicious JavaScript could be executed on the documentation site
* Supply chain attack vector: Third-party CDN compromise affects all sites loading from polyfill.io
* User safety: Visitors to the documentation could be exposed to malicious scripts