### PR TITLE
[CI] Update actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10"]
     steps:
         - name: Checkout main code
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install pre-commit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,11 @@ jobs:
             id-token: write
         steps:
         - name: Check out mis
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
           with:
             ref: ${{ github.ref }}
         - name: Set up Python
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: "3.11"
         - name: Install Python dependencies
@@ -36,7 +36,7 @@ jobs:
           run: |
             hatch build
         - name: Publish to PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
+          uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         - name: Confirm deployment
           timeout-minutes: 5
           run: |
@@ -52,7 +52,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Checkout mis
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: Install JetBrains Mono font
           run: |
             sudo apt install -y wget unzip fontconfig
@@ -64,7 +64,7 @@ jobs:
         - name: Install graphviz
           run: sudo apt-get install -y graphviz
         - name: Set up Python 3.11
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: '3.11'
         - name: Install Hatch

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,8 +26,8 @@ jobs:
       contents: read
       security-events: write  # Required for SARIF upload
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - run: pip install bandit[toml,sarif]
@@ -35,7 +35,7 @@ jobs:
         run: bandit -r qubosolver/ -c pyproject.toml -f sarif -o bandit-results.sarif || true  #TODO: remove 'true' once all warnings are fixed
       - name: Upload Bandit SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: bandit-results.sarif
 
@@ -43,7 +43,7 @@ jobs:
     name: Secret Detection - Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Install Gitleaks
@@ -62,7 +62,7 @@ jobs:
       contents: write
       security-events: write  # Required for SARIF upload to GitHub Security tab
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python virtual environment
         run: |
@@ -79,24 +79,35 @@ jobs:
           uv export --format requirements-txt --no-hashes -o requirements.txt
           rm uv.lock
 
-      - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@v0.36.0
+      - name: Run Trivy scan # Detect vulnerabilities and fails if vulnerabilities are found
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        continue-on-error: ${{ github.ref }} != 'refs/heads/main'
         with:
+          version: v0.71.0
+          scan-type: fs
+          scan-ref: .
+          format: table
+          exit-code: "1"
+          severity: CRITICAL,HIGH
+
+      - name: Run Trivy scan for upload # Never fails so the SARIF file is always available
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.71.0
           scan-type: fs
           scan-ref: .
           format: sarif
           output: trivy-results.sarif
-          exit-code: "1"
-          severity: CRITICAL,HIGH
+          exit-code: "0"
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-results.sarif
 
       - name: Generate SBOM (CycloneDX)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -106,13 +117,13 @@ jobs:
         env:
           VIRTUAL_ENV: ${{ env.VIRTUAL_ENV }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v0.7.1
         with:
-          name: sbom
+          name: trivy-sbom
           path: sbom.cdx.json
 
       - name: Submit Dependency Snapshot to GitHub Dependency Graph
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,15 +64,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Set up Python virtual environment
-        run: |
-          pip install uv
-          uv venv .venv
-          echo "VIRTUAL_ENV=${{ github.workspace }}/.venv" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: 0.11.18
 
       - name: Install dependencies
-        run: uv sync -U
+        run: uv sync -p 3.12 -U
 
       - name: Generate requirements.txt
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
         - name: Checkout main code and submodules
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install hatch
@@ -40,7 +40,7 @@ jobs:
           run: |
             hatch -v run test
         - name: Upload coverage reports to Codecov
-          uses: codecov/codecov-action@v5
+          uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
           with:
             token: ${{ secrets.CODECOV_TOKEN }}
             slug: pasqal-io/qubo-solver
@@ -53,9 +53,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
         - name: Checkout main code and submodules
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install hatch
@@ -66,7 +66,7 @@ jobs:
           run: |
             hatch -v run test
         - name: Upload coverage reports to Codecov
-          uses: codecov/codecov-action@v5
+          uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
           with:
             token: ${{ secrets.CODECOV_TOKEN }}
             slug: pasqal-io/qubo-solver
@@ -80,9 +80,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout mis
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Hatch
@@ -100,9 +100,9 @@ jobs:
         python-version: ["3.11"]
     steps:
         - name: Checkout main code and submodules
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v6
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install hatch


### PR DESCRIPTION
Bumps GitHub Actions dependencies to newer major versions:
- actions/checkout → v6
- actions/setup-python → v6
- actions/upload-artifact / actions/download-artifact → v7

Switches Python dependency installation to use the uv action instead of a manual install step.

Security hardening: pin GitHub Actions uses: references to commit SHAs (after a short “soak time”) to reduce supply‑chain risk from upstream tag changes.

Closes #169, #166, #165