### PR TITLE
187 time limit for tabu search

### DIFF
--- a/docs/content/classical/heuristics/simulatedannealing.md
+++ b/docs/content/classical/heuristics/simulatedannealing.md
@@ -17,7 +17,7 @@ This solver uses a Simulated Annealing to probabilistically explore the solution
 
 | Field                   | Type              | Description                                                                                        |
 | ----------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
-| `use_quantum`           | `bool`            | Have to be `False` to uses a classical solver.                                                     |
+| `use_quantum`           | `bool`            | Have to be `False` to use a classical solver.                                                      |
 | `classical_solver_type` | `str`             | Set to `"simulated_annealing"` to use Simulated Annealing as the solving method.                   |
 | `max_iter`              | `int`             | Maximum number of iterations to perform for simulated annealing or tabu search.                    |
 | `sa_initial_temp`       | `float`           | Starting temperature (controls exploration).                                                       |

--- a/docs/content/classical/heuristics/tabu.md
+++ b/docs/content/classical/heuristics/tabu.md
@@ -15,14 +15,14 @@ This solver applies a Tabu Search metaheuristic to escape local minima and explo
 
 ## Fields
 
-| Field                   | Type                    | Description                                                                              |
-| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
-| `use_quantum`           | `bool`                  | Have to be `False` to uses a classical solver.                                           |
-| `classical_solver_type` | `str`                   | Set to `"tabu_search"` to use Tabu Search as the solving method.                         |
-| `tabu_x0`               | `torch.Tensor` | `None` | The initial binary solution tensor.                                                      |
-| `tabu_tenure`           | `int`                   | Number of iterations a move (bit flip) remains tabu.                                     |
-| `tabu_max_no_improve`   | `int`                   | Maximum number of consecutive iterations without improvement before termination.         |
-| `tabu_time_limit`       | `float` | `None`        | Maximum execution time for Tabu Search, in seconds. If `None`, no time limit is applied. |
+| Field                   | Type                    | Description                                                                                |
+| ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------ |
+| `use_quantum`           | `bool`                  | Have to be `False` to use a classical solver.                                              |
+| `classical_solver_type` | `str`                   | Set to `"tabu_search"` to use Tabu Search as the solving method.                           |
+| `tabu_x0`               | `torch.Tensor` | `None` | The initial binary solution tensor.                                                        |
+| `tabu_tenure`           | `int`                   | Number of iterations a move (bit flip) remains tabu.                                       |
+| `tabu_max_no_improve`   | `int`                   | Maximum number of consecutive iterations without improvement before termination.           |
+| `tabu_time_limit`       | `float`                 | Maximum execution time for Tabu Search, in seconds. If infinite, no time limit is applied. |
 
 ### Usage
 

--- a/docs/content/classical/heuristics/tabu.md
+++ b/docs/content/classical/heuristics/tabu.md
@@ -3,32 +3,36 @@
 Classical solver using Tabu Search. Designed to integrate with the solver factory.
 
 ### Signature
+
 ```python
 class TabuSearchSolver(BaseClassicalSolver):
     def solve(self) -> QUBOSolution
 ```
 
 ### Description
+
 This solver applies a Tabu Search metaheuristic to escape local minima and explore the solution space. It is suitable for solving QUBO instances classically without relying on quantum hardware. The implementation is based on `TabuSearchSolver` from the Ocean SDK, and returns solutions compatible with the `QUBOSolution` interface used across the `qubo-solver` package.
 
 ## Fields
 
-| Field                  | Type    | Description |
-|------------------------|---------|-------------|
-| `use_quantum`           | `bool`  | Have to be `False` to uses a classical solver. |
-| `classical_solver_type` | `str`   | Set to `"tabu_search"` to use Tabu Search as the solving method. |
-| `tabu_x0`    | `torch.Tensor` \| `None` | The initial binary solution tensor. |
-| `tabu_tenure`    | `int` | Number of iterations a move (bit flip) remains tabu. |
-| `tabu_max_no_improve`    | `int` | Maximum number of consecutive iterations without improvement before termination. |
+| Field                   | Type                    | Description                                                                              |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
+| `use_quantum`           | `bool`                  | Have to be `False` to uses a classical solver.                                           |
+| `classical_solver_type` | `str`                   | Set to `"tabu_search"` to use Tabu Search as the solving method.                         |
+| `tabu_x0`               | `torch.Tensor` | `None` | The initial binary solution tensor.                                                      |
+| `tabu_tenure`           | `int`                   | Number of iterations a move (bit flip) remains tabu.                                     |
+| `tabu_max_no_improve`   | `int`                   | Maximum number of consecutive iterations without improvement before termination.         |
+| `tabu_time_limit`       | `float` | `None`        | Maximum execution time for Tabu Search, in seconds. If `None`, no time limit is applied. |
 
 ### Usage
+
 ```python exec="on" source="material-block" html="1"
 from qubosolver import QUBOInstance
 from qubosolver.solver import QuboSolver
 from qubosolver.config import SolverConfig, ClassicalConfig
 
 qubo = QUBOInstance(coefficients=[[-2.0, 1.0], [1.0, -2.0]])
-config = SolverConfig(use_quantum = False, classical=ClassicalConfig(classical_solver_type="tabu_search"))
+config = SolverConfig(use_quantum = False, classical=ClassicalConfig(classical_solver_type="tabu_search", tabu_time_limit=300.0))
 
 solver = QuboSolver(qubo, config)
 
@@ -37,4 +41,5 @@ print(solution)
 ```
 
 ### Notes
+
 Recommended for classical heuristics when reproducibility and control over local search dynamics are desired.

--- a/docs/tutorial/07-classical-heuristics.ipynb
+++ b/docs/tutorial/07-classical-heuristics.ipynb
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -146,8 +146,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial/07-classical-heuristics.ipynb
+++ b/docs/tutorial/07-classical-heuristics.ipynb
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -115,12 +115,19 @@
     "from qubosolver.config import SolverConfig, ClassicalConfig\n",
     "\n",
     "qubo = QUBOInstance(coefficients=[[-2.0, 1.0], [1.0, -2.0]])\n",
-    "config = SolverConfig(use_quantum = False, classical=ClassicalConfig(classical_solver_type=\"simulated_annealing_tabu_search\", max_bitstrings=2))\n",
+    "config = SolverConfig(\n",
+    "    use_quantum=False,\n",
+    "    classical=ClassicalConfig(\n",
+    "        classical_solver_type=\"simulated_annealing_tabu_search\",\n",
+    "        max_bitstrings=2,\n",
+    "        tabu_time_limit=300.0,\n",
+    "    ),\n",
+    ")\n",
     "\n",
     "solver = QuboSolver(qubo, config)\n",
     "\n",
     "solution = solver.solve()\n",
-    "print(solution)"
+    "print(solution)\n"
    ]
   }
  ],

--- a/docs/tutorial/07-classical-heuristics.ipynb
+++ b/docs/tutorial/07-classical-heuristics.ipynb
@@ -139,7 +139,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/qubosolver/classical_solver/classical_solver.py
+++ b/qubosolver/classical_solver/classical_solver.py
@@ -155,6 +155,7 @@ class TabuSearchSolver(BaseClassicalSolver):
             tabu_tenure=self.config.tabu_tenure,
             max_no_improve=self.config.tabu_max_no_improve,
             max_bitstrings=self.config.max_bitstrings,
+            time_limit=self.config.tabu_time_limit,
         )
         return tabu_search_solution
 

--- a/qubosolver/classical_solver/tabu_search.py
+++ b/qubosolver/classical_solver/tabu_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import torch
 
 from qubosolver import QUBOInstance, QUBOSolution
@@ -13,6 +15,7 @@ def qubo_tabu_search(
     tabu_tenure: int = 7,
     max_no_improve: int = 20,
     max_bitstrings: int = 1,
+    time_limit: float | None = None,
 ) -> QUBOSolution:
     """
     Solve a QUBO problem using a simple Tabu Search heuristic.
@@ -29,6 +32,8 @@ def qubo_tabu_search(
         tabu_tenure: Number of iterations a flipped variable remains tabu.
         max_no_improve: Stop criterion based on consecutive iterations
             without improvement.
+        time_limit: Maximum execution time in seconds. If `None`, no time
+            limit is applied.
 
     Returns:
         A `QUBOSolution` object containing:
@@ -41,6 +46,11 @@ def qubo_tabu_search(
         >>> solution = qubo_tabu_search(qubo, x0=torch.randint(0, 2, (10,)))
         >>> print(solution)
     """
+    if time_limit is not None and time_limit <= 0:
+        raise ValueError("time_limit must be greater than 0.")
+
+    deadline = None if time_limit is None else time.perf_counter() + time_limit
+
     best_solutions, costs, counts = tabu_search(
         qubo=qubo,
         x0=x0,
@@ -48,6 +58,7 @@ def qubo_tabu_search(
         tabu_tenure=tabu_tenure,
         max_no_improve=max_no_improve,
         max_bitstrings=max_bitstrings,
+        deadline=deadline,
     )
     return QUBOSolution(
         bitstrings=best_solutions,
@@ -64,6 +75,7 @@ def tabu_search(
     tabu_tenure: int = 7,
     max_no_improve: int = 20,
     max_bitstrings: int = 1,
+    deadline: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Perform Tabu Search on a QUBO instance to find low-cost bitstrings.
@@ -84,6 +96,8 @@ def tabu_search(
             without improvement before termination. Defaults to 20.
         max_bitstrings (int, optional): Maximum number of bitstring solutions returned.
             Defaults to 1.
+        deadline (float, optional): Absolute time at which the search must stop.
+            Defaults to None.
 
     Returns:
         A tuple `(bistrings, costs, counts)` where:
@@ -109,6 +123,9 @@ def tabu_search(
     tabu_list = torch.zeros((max_bitstrings, n), dtype=torch.int64, device=device)
     iter_since_last_improve = torch.zeros(max_bitstrings, dtype=torch.int64, device=device)
     for iteration in range(max_iter):
+        if deadline is not None and time.perf_counter() >= deadline:
+            break
+
         # Generate all neighbor candidates for each bit flip
         flips = torch.eye(n, dtype=torch.int64, device=device).unsqueeze(0)
         x_neighbors = x_current.unsqueeze(1).clone()

--- a/qubosolver/classical_solver/tabu_search.py
+++ b/qubosolver/classical_solver/tabu_search.py
@@ -15,7 +15,7 @@ def qubo_tabu_search(
     tabu_tenure: int = 7,
     max_no_improve: int = 20,
     max_bitstrings: int = 1,
-    time_limit: float | None = None,
+    time_limit: float = float("inf"),
 ) -> QUBOSolution:
     """
     Solve a QUBO problem using a simple Tabu Search heuristic.
@@ -32,7 +32,7 @@ def qubo_tabu_search(
         tabu_tenure: Number of iterations a flipped variable remains tabu.
         max_no_improve: Stop criterion based on consecutive iterations
             without improvement.
-        time_limit: Maximum execution time in seconds. If `None`, no time
+        time_limit: Maximum execution time in seconds. If infinite, no time
             limit is applied.
 
     Returns:
@@ -46,10 +46,8 @@ def qubo_tabu_search(
         >>> solution = qubo_tabu_search(qubo, x0=torch.randint(0, 2, (10,)))
         >>> print(solution)
     """
-    if time_limit is not None and time_limit <= 0:
+    if time_limit <= 0:
         raise ValueError("time_limit must be greater than 0.")
-
-    deadline = None if time_limit is None else time.perf_counter() + time_limit
 
     best_solutions, costs, counts = tabu_search(
         qubo=qubo,
@@ -58,7 +56,7 @@ def qubo_tabu_search(
         tabu_tenure=tabu_tenure,
         max_no_improve=max_no_improve,
         max_bitstrings=max_bitstrings,
-        deadline=deadline,
+        time_limit=time_limit,
     )
     return QUBOSolution(
         bitstrings=best_solutions,
@@ -75,7 +73,7 @@ def tabu_search(
     tabu_tenure: int = 7,
     max_no_improve: int = 20,
     max_bitstrings: int = 1,
-    deadline: float | None = None,
+    time_limit: float = float("inf"),
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Perform Tabu Search on a QUBO instance to find low-cost bitstrings.
@@ -96,8 +94,8 @@ def tabu_search(
             without improvement before termination. Defaults to 20.
         max_bitstrings (int, optional): Maximum number of bitstring solutions returned.
             Defaults to 1.
-        deadline (float, optional): Absolute time at which the search must stop.
-            Defaults to None.
+        time_limit: Maximum execution time in seconds. If infinite, no time
+            limit is applied. Defaults to float('inf').
 
     Returns:
         A tuple `(bistrings, costs, counts)` where:
@@ -122,8 +120,11 @@ def tabu_search(
     # Tabu list per run and bit
     tabu_list = torch.zeros((max_bitstrings, n), dtype=torch.int64, device=device)
     iter_since_last_improve = torch.zeros(max_bitstrings, dtype=torch.int64, device=device)
+
+    deadline = time.perf_counter() + time_limit
+
     for iteration in range(max_iter):
-        if deadline is not None and time.perf_counter() >= deadline:
+        if time.perf_counter() >= deadline:
             break
 
         # Generate all neighbor candidates for each bit flip

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -66,7 +66,9 @@ class ClassicalConfig(Config):
         tabu_x0 (torch.Tensor | None, optional): The initial binary solution tensor of shape (n,).
         tabu_tenure (int, optional): Number of iterations a move (bit flip) remains tabu.
         tabu_max_no_improve (int, optional): Maximum number of consecutive iterations
-            without improvement before termination.
+        without improvement before termination.
+        tabu_time_limit (float | None, optional): Maximum execution time for tabu search,
+        in seconds. Defaults to None.
     """
 
     classical_solver_type: str | ClassicalSolverType = "simulated_annealing_tabu_search"
@@ -87,6 +89,7 @@ class ClassicalConfig(Config):
     tabu_x0: torch.Tensor | None = None
     tabu_tenure: int = 7
     tabu_max_no_improve: int = 20
+    tabu_time_limit: float | None = None
 
     @field_validator("classical_solver_type")
     @classmethod
@@ -132,6 +135,7 @@ class ClassicalConfig(Config):
                     "tabu_x0": self.tabu_x0,
                     "tabu_tenure": self.tabu_tenure,
                     "tabu_max_no_improve": self.tabu_max_no_improve,
+                    "tabu_time_limit": self.tabu_time_limit,
                 }
             )
         if self.classical_solver_type == ClassicalSolverType.SIMULATED_ANNEALING_TABU_SEARCH:
@@ -149,6 +153,7 @@ class ClassicalConfig(Config):
                     "tabu_x0": self.tabu_x0,
                     "tabu_tenure": self.tabu_tenure,
                     "tabu_max_no_improve": self.tabu_max_no_improve,
+                    "tabu_time_limit": self.tabu_time_limit,
                 }
             )
         return serialization

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -59,16 +59,16 @@ class ClassicalConfig(Config):
         sa_final_temp (float, optional): Minimum temperature threshold for stopping.
         sa_cooling_rate (float, optional): Cooling rate - should be slightly below 1 (e.g., 0.95–0.99).
         sa_seed (int, optional): Random seed for reproducibility.
-        sa_start (torch.Tensor | None, optional): Optioanl initial bitstring of shape (n,).
+        sa_start (torch.Tensor | None, optional): Optional initial bitstring of shape (n,).
         sa_energy_tol (float, optional): Energy tolerance for considering two solutions as equivalent.
         sa_time_limit (float): Maximum runtime in seconds for simulated annealing.
             Defaults to float('inf'), meaning no time limit.
         tabu_x0 (torch.Tensor | None, optional): The initial binary solution tensor of shape (n,).
         tabu_tenure (int, optional): Number of iterations a move (bit flip) remains tabu.
         tabu_max_no_improve (int, optional): Maximum number of consecutive iterations
-        without improvement before termination.
-        tabu_time_limit (float | None, optional): Maximum execution time for tabu search,
-        in seconds. Defaults to None.
+            without improvement before termination.
+        tabu_time_limit (float): Maximum execution time for tabu search,
+            in seconds. Defaults to float("inf").
     """
 
     classical_solver_type: str | ClassicalSolverType = "simulated_annealing_tabu_search"
@@ -89,7 +89,7 @@ class ClassicalConfig(Config):
     tabu_x0: torch.Tensor | None = None
     tabu_tenure: int = 7
     tabu_max_no_improve: int = 20
-    tabu_time_limit: float | None = None
+    tabu_time_limit: float = float("inf")
 
     @field_validator("classical_solver_type")
     @classmethod

--- a/tests/solvers/test_heuristics.py
+++ b/tests/solvers/test_heuristics.py
@@ -145,6 +145,34 @@ def test_sa_cost(
         cost_sa = cost_sa.to(dtype=cost.dtype)
         assert torch.isclose(cost, cost_sa, rtol=1e-4)
 
+def test_tabu_time_limit(simple_qubo_instance: QUBOInstance) -> None:
+    # Set max_iter and max_no_improve to very large values to ensure that
+    # the solver is stopped by tabu_time_limit, not by another stop criterion.
+    classical_config = ClassicalConfig(
+        classical_solver_type=ClassicalSolverType.TABU_SEARCH,
+        max_bitstrings=1,
+        max_iter=100_000_000,
+        tabu_max_no_improve=100_000_000,
+        tabu_time_limit=0.01,
+    )
+
+    config = SolverConfig(
+        use_quantum=False,
+        classical=classical_config,
+        activate_trivial_solutions=False,
+    )
+
+    classical_solver = QuboSolver(simple_qubo_instance, config)
+
+    # Measure the full execution time of the solver.
+    start_time = time.perf_counter()
+    solution = classical_solver.solve()
+    elapsed_time = time.perf_counter() - start_time
+
+    # Check that a valid solution is returned and that the solver
+    # stops well before reaching the large iteration limit.
+    assert isinstance(solution, QUBOSolution)
+    assert elapsed_time < 1.0
 
 def test_sa_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     # Use a very large iteration limit so that the solver is stopped

--- a/tests/solvers/test_heuristics.py
+++ b/tests/solvers/test_heuristics.py
@@ -204,5 +204,6 @@ def test_sa_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     assert isinstance(solution, QUBOSolution)
     assert elapsed_time < 1.0
 
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/solvers/test_heuristics.py
+++ b/tests/solvers/test_heuristics.py
@@ -145,6 +145,7 @@ def test_sa_cost(
         cost_sa = cost_sa.to(dtype=cost.dtype)
         assert torch.isclose(cost, cost_sa, rtol=1e-4)
 
+
 def test_tabu_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     # Set max_iter and max_no_improve to very large values to ensure that
     # the solver is stopped by tabu_time_limit, not by another stop criterion.
@@ -174,6 +175,7 @@ def test_tabu_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     assert isinstance(solution, QUBOSolution)
     assert elapsed_time < 1.0
 
+
 def test_sa_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     # Use a very large iteration limit so that the solver is stopped
     # by the time limit rather than by max_iter.
@@ -201,7 +203,6 @@ def test_sa_time_limit(simple_qubo_instance: QUBOInstance) -> None:
     # stops well before reaching the large iteration limit.
     assert isinstance(solution, QUBOSolution)
     assert elapsed_time < 1.0
-
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Summary

- Add `tabu_time_limit` to the classical solver configuration
- Propagate the parameter to the Tabu Search solver
- Stop Tabu Search when the time limit is reached
- Add unit tests for the new time limit behavior
- Update the Tabu Search documentation

## Testing

- Unit tests pass locally
- Pre-commit checks pass