### PR TITLE
[Config] Change defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: mypy
         exclude: examples|docs
         additional_dependencies:
-          - "qoolqit[extras]>=1.1" # The version in pyproject.toml must match
+          - "qoolqit[extras]>=1.1.1" # The version in pyproject.toml must match
 
 # Cleanup jupyter notebooks
 -   repo: https://github.com/srstevenson/nb-clean

--- a/docs/content/backend.md
+++ b/docs/content/backend.md
@@ -9,7 +9,7 @@ The backend configuration part in `SolverConfig` is set via two fields.
 | Field         | Type          | Description |
 |---------------|---------------|-------------|
 | `backend`     | `LocalEmulator` \| `RemoteEmulator` \| `QPU` | (optional) Which backend to use. |
-| `device`      | `Device` | (optional) The quantum device specification. Defaults to `DigitalAnalogDevice`.|
+| `device`      | `Device` | (optional) The quantum device specification. Defaults to `AnalogDeviceWithDMM`.|
 
 
 ## Local backends
@@ -31,20 +31,13 @@ To use the automatic selection, simply instantiate a `SolverConfig` with a `Loca
 ```python exec="on" source="material-block"
 from qubosolver.config import SolverConfig, LocalEmulator
 from qubosolver.backends import AutoLocalEmulatorBackend
-from qoolqit import DigitalAnalogDevice
+from qoolqit import AnalogDeviceWithDMM
 
 # Automatic backend selection based on problem size (default behavior)
 config = SolverConfig(
     use_quantum=True,
     backend=LocalEmulator(num_shots=500),  # Uses AutoLocalEmulatorBackend by default
-    device=DigitalAnalogDevice(),
-)
-
-# Explicitly specify automatic backend selection
-config_explicit = SolverConfig(
-    use_quantum=True,
-    backend=LocalEmulator(backend_type=AutoLocalEmulatorBackend, num_shots=500),
-    device=DigitalAnalogDevice(),
+    device=AnalogDeviceWithDMM(),
 )
 ```
 
@@ -55,7 +48,7 @@ from qubosolver.config import SolverConfig, LocalEmulator
 from pulser_simulation import QutipBackendV2
 from emu_sv import SVBackend
 from emu_mps import MPSBackend
-from qoolqit import DigitalAnalogDevice
+from qoolqit import AnalogDeviceWithDMM
 
 # Manual backend selection
 manual_backends = [
@@ -67,7 +60,7 @@ manual_backends = [
 config = SolverConfig(
     use_quantum=True,
     backend=manual_backends[0],  # Use QutipBackendV2
-    device=DigitalAnalogDevice(),
+    device=AnalogDeviceWithDMM(),
 )
 ```
 

--- a/docs/tutorial/04-qubo-embedding.ipynb
+++ b/docs/tutorial/04-qubo-embedding.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "from qubosolver.config import EmbeddingConfig, SolverConfig\n",
     "from qubosolver.solver import QUBOInstance, QuboSolver\n",
-    "from qoolqit import DigitalAnalogDevice\n",
+    "from qoolqit import AnalogDeviceWithDMM\n",
     "import matplotlib.pyplot as plt\n",
     "import warnings\n",
     "plt.rcParams[\"animation.html\"] = \"jshtml\"\n",
@@ -194,7 +194,7 @@
     "blade_settings = EmbeddingConfig(embedding_method=\"blade\", blade_dimensions=[5 ,4, 3, 2], blade_steps_per_round=300)\n",
     "blade_config = SolverConfig.from_kwargs(\n",
     "    use_quantum=True,\n",
-    "    device=DigitalAnalogDevice(),\n",
+    "    device=AnalogDeviceWithDMM(),\n",
     "    embedding=blade_settings,\n",
     ")\n",
     "\n",
@@ -209,7 +209,7 @@
    "metadata": {},
    "source": [
     "### Greedy embedder parametrization\n",
-    "We do the same using the `greedy` embedding method, using a triangular lattice layout on a `DigitalAnalogDevice` with a number of greedy_traps at least equal to the number of variables in the QUBO (with `-1` the number of traps is automatically set to the device capacity):"
+    "We do the same using the `greedy` embedding method, using a triangular lattice layout on a `AnalogDeviceWithDMM` with a number of greedy_traps at least equal to the number of variables in the QUBO (with `-1` the number of traps is automatically set to the device capacity):"
    ]
   },
   {
@@ -234,7 +234,7 @@
     "\n",
     "greedy_config = SolverConfig.from_kwargs(\n",
     "    use_quantum=True,\n",
-    "    device=DigitalAnalogDevice(),\n",
+    "    device=AnalogDeviceWithDMM(),\n",
     "    embedding=greedy_settings,\n",
     ")\n",
     "\n",
@@ -49661,7 +49661,7 @@
     "cfg = SolverConfig.from_kwargs(\n",
     "    use_quantum=True,\n",
     "    embedding=greedy_settings,\n",
-    "    device=DigitalAnalogDevice(),\n",
+    "    device=AnalogDeviceWithDMM(),\n",
     ")\n",
     "\n",
     "solver = QuboSolver(instance, cfg)\n",

--- a/docs/tutorial/06-drive-shaping-methods.ipynb
+++ b/docs/tutorial/06-drive-shaping-methods.ipynb
@@ -18,7 +18,7 @@
     "**Default SolverConfig parameters to run a quantum approach:**\n",
     "- use_quantum: bool = False (*for using the drive shaping methods, we have to set it to `True`.*)\n",
     "- backend: LocalEmulator | RemoteEmulator | QPU (by default, use a LocalEmulator based on qutip)\n",
-    "- device: Device = DigitalAnalogDevice() (also available: `AnalogDevice()`)\n",
+    "- device: Device = AnalogDeviceWithDMM() (also available: `AnalogDevice()`)\n",
     "- embedding_method: str | EmbedderType | None = EmbedderType.GREEDY (also available: `BLADE`)\n",
     "- drive_shaping_method: str | DriveType | None = DriveType.HEURISTIC (also available: `OPTIMIZED`)\n"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "scikit-optimize",
   "cplex",
   "pydantic>=2",
-  "qoolqit[extras]>=1.1", # The version in .pre-commit-config.yaml must match
+  "qoolqit[extras]>=1.1.1", # The version in .pre-commit-config.yaml must match
   "shapely",
 ]
 

--- a/qubosolver/algorithms/greedy/greedy.py
+++ b/qubosolver/algorithms/greedy/greedy.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import torch
 from pulser.register.register_layout import RegisterLayout
-from qoolqit.devices.device import DigitalAnalogDevice
+from qoolqit.devices.device import AnalogDeviceWithDMM
 
 from qubosolver.qubo_types import LayoutType
 
@@ -689,7 +689,7 @@ class Greedy:
 
         lb_radius = params["device"].rydberg_blockade_radius(1)
         ub_radius = params["device"].rydberg_blockade_radius(
-            1 if isinstance(params["device"], DigitalAnalogDevice) else 200
+            1 if isinstance(params["device"], AnalogDeviceWithDMM) else 200
         )
         blockade_radius = (ub_radius - lb_radius) + lb_radius
         omega = params["device"].rabi_from_blockade(blockade_radius)

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 import torch
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator, model_serializer
 
-from qoolqit.devices.device import Device, DigitalAnalogDevice
+from qoolqit.devices.device import Device, AnalogDeviceWithDMM
 from qoolqit.execution import QPU
 from qoolqit.execution.compilation_functions import CompilerProfile
 from pulser_pasqal import PasqalCloud
@@ -184,7 +184,7 @@ class EmbeddingConfig(Config):
         animation_save_path (str | None, optional): If provided, path to save animation.
             Defaults to None.
         min_distance (float | None): Minimum atom separation (μm).
-            If not None, the resulting register will be normalized so that the minimum atom separation is equal to this value. Should be 1.0001 when using the Heuristic Drive-Shaping, and None when using the Optimized Drive-Shaping. Defaults to None.
+            If not None, the resulting register will be normalized so that the minimum atom separation is equal to this value. Should be 1.001 when using the Heuristic Drive-Shaping, and None when using the Optimized Drive-Shaping. Defaults to 1.001.
     """
 
     embedding_method: Any = EmbedderType.GREEDY
@@ -197,7 +197,7 @@ class EmbeddingConfig(Config):
     blade_dimensions: list[int] = field(default_factory=lambda: [5, 4, 3, 2, 2, 2])
     draw_steps: bool = False
     animation_save_path: str | None = None
-    min_distance: float | None = None
+    min_distance: float | None = 1.001
 
     @model_serializer(mode="plain")
     def serialize_model(self) -> dict[str, Any]:
@@ -423,7 +423,7 @@ class SolverConfig(Config):
             hence they are deprecated compared to previous qubo-solver versions.
             Also the number of shots is set there as well.
             Defaults to a LocalEmulator using qutip.
-        device (Device, optional): The quantum device specification. Defaults to `DigitalAnalogDevice`.
+        device (Device, optional): The quantum device specification. Defaults to `AnalogDeviceWithDMM`.
         do_postprocessing (bool, optional): Whether we apply post-processing (`True`) or not (`False`).
             Defaults to True.
         do_preprocessing (bool, optional): Whether we apply pre-processing (`True`) or not (`False`).
@@ -440,7 +440,7 @@ class SolverConfig(Config):
     drive_shaping: DriveShapingConfig = DriveShapingConfig()
     classical: ClassicalConfig = ClassicalConfig()
     backend: LocalEmulator | RemoteEmulator | QPU = LocalEmulator()
-    device: Device = DigitalAnalogDevice()
+    device: Device = AnalogDeviceWithDMM()
     do_postprocessing: bool = False
     do_preprocessing: bool = False
     activate_trivial_solutions: bool = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from pulser_simulation import QutipBackendV2
 from emu_sv import SVBackend
 from emu_mps import MPSBackend
 
-from qoolqit.devices import DigitalAnalogDevice, AnalogDevice, Device, MockDevice
+from qoolqit.devices import AnalogDeviceWithDMM, AnalogDevice, Device, MockDevice
 from pulser_pasqal import PasqalCloud
 from qubosolver import QUBOInstance, QUBOSolution
 from qubosolver.qubo_analyzer import QUBOAnalyzer
@@ -115,13 +115,13 @@ def local_backend(request: pytest.FixtureRequest) -> LocalEmulator:
 
 @pytest.fixture(
     params=[
-        DigitalAnalogDevice(),
+        AnalogDeviceWithDMM(),
         AnalogDevice(),
         MockDevice(),
         Device(pulser_device=connection.fetch_available_devices()["FRESNEL"]),
     ],
     ids=[
-        "DigitalAnalogDevice",
+        "AnalogDeviceWithDMM",
         "AnalogDevice",
         "MockDevice",
         "FRESNEL",

--- a/tests/drive_shaping/test_heuristic.py
+++ b/tests/drive_shaping/test_heuristic.py
@@ -13,7 +13,7 @@ from qubosolver import QUBOInstance
 from qubosolver.solver import QuboSolver
 from qubosolver.config import EmbeddingConfig, SolverConfig, DriveShapingConfig
 from qubosolver.qubo_analyzer import QUBOAnalyzer
-from qoolqit import AnalogDeviceWithDMM, AnalogDevice
+from qoolqit import AnalogDeviceWithDMM, AnalogDevice, DigitalAnalogDevice
 
 
 @dataclass
@@ -49,7 +49,7 @@ def gather_optimal_solutions(
 @pytest.mark.usefixtures("restore_rng_state")
 @pytest.mark.parametrize("seed", [4548, 33671, 195530])
 @pytest.mark.parametrize("dmm", [True, False], ids=["dmm", "no_dmm"])
-@pytest.mark.parametrize("device_type", [AnalogDeviceWithDMM, AnalogDevice])
+@pytest.mark.parametrize("device_type", [DigitalAnalogDevice, AnalogDevice])
 @pytest.mark.parametrize("constant_diagonal", [True, False], ids=["cst_diag", "var_diag"])
 @pytest.mark.parametrize("diagonal_scale", [-0.9, -3.0, -1.5, -6.0])
 def test_with_perfect_embedding(
@@ -158,4 +158,4 @@ def test_with_perfect_embedding(
         check.is_in(solution.bitstring, expected_optimal_bistrings)
 
     cumulated_probability = sum(s.probability for s in optimal_solutions)
-    check.greater(cumulated_probability, 0.5)
+    check.greater(cumulated_probability, 0.75)

--- a/tests/drive_shaping/test_heuristic.py
+++ b/tests/drive_shaping/test_heuristic.py
@@ -13,7 +13,7 @@ from qubosolver import QUBOInstance
 from qubosolver.solver import QuboSolver
 from qubosolver.config import EmbeddingConfig, SolverConfig, DriveShapingConfig
 from qubosolver.qubo_analyzer import QUBOAnalyzer
-from qoolqit import DigitalAnalogDevice, AnalogDevice
+from qoolqit import AnalogDeviceWithDMM, AnalogDevice
 
 
 @dataclass
@@ -49,13 +49,13 @@ def gather_optimal_solutions(
 @pytest.mark.usefixtures("restore_rng_state")
 @pytest.mark.parametrize("seed", [4548, 33671, 195530])
 @pytest.mark.parametrize("dmm", [True, False], ids=["dmm", "no_dmm"])
-@pytest.mark.parametrize("device_type", [DigitalAnalogDevice, AnalogDevice])
+@pytest.mark.parametrize("device_type", [AnalogDeviceWithDMM, AnalogDevice])
 @pytest.mark.parametrize("constant_diagonal", [True, False], ids=["cst_diag", "var_diag"])
 @pytest.mark.parametrize("diagonal_scale", [-0.9, -3.0, -1.5, -6.0])
 def test_with_perfect_embedding(
     seed: int,
     dmm: bool,
-    device_type: type[DigitalAnalogDevice] | type[AnalogDevice],
+    device_type: type[AnalogDeviceWithDMM] | type[AnalogDevice],
     constant_diagonal: bool,
     diagonal_scale: float,
 ) -> None:
@@ -158,4 +158,4 @@ def test_with_perfect_embedding(
         check.is_in(solution.bitstring, expected_optimal_bistrings)
 
     cumulated_probability = sum(s.probability for s in optimal_solutions)
-    check.greater(cumulated_probability, 0.75)
+    check.greater(cumulated_probability, 0.5)

--- a/tests/drive_shaping/test_heuristic.py
+++ b/tests/drive_shaping/test_heuristic.py
@@ -13,7 +13,7 @@ from qubosolver import QUBOInstance
 from qubosolver.solver import QuboSolver
 from qubosolver.config import EmbeddingConfig, SolverConfig, DriveShapingConfig
 from qubosolver.qubo_analyzer import QUBOAnalyzer
-from qoolqit import AnalogDeviceWithDMM, AnalogDevice, DigitalAnalogDevice
+from qoolqit import AnalogDevice, DigitalAnalogDevice
 
 
 @dataclass
@@ -55,7 +55,7 @@ def gather_optimal_solutions(
 def test_with_perfect_embedding(
     seed: int,
     dmm: bool,
-    device_type: type[AnalogDeviceWithDMM] | type[AnalogDevice],
+    device_type: type[DigitalAnalogDevice] | type[AnalogDevice],
     constant_diagonal: bool,
     diagonal_scale: float,
 ) -> None:

--- a/tests/drive_shaping/test_optimized.py
+++ b/tests/drive_shaping/test_optimized.py
@@ -10,7 +10,7 @@ import pytest_check as check
 from unittest.mock import MagicMock, patch
 from typing import List, Iterable, Dict, Any
 
-from qoolqit.devices.device import DigitalAnalogDevice, AnalogDevice
+from qoolqit.devices.device import AnalogDeviceWithDMM, AnalogDevice
 from qoolqit.register import Register
 
 from qubosolver.pipeline.drive import OptimizedDriveShaper
@@ -272,7 +272,7 @@ def test_errors(raise_exception: bool) -> None:
     ds_config.optimized_callback_objective = mock_callback
     ds_config.optimized_n_calls = 11
     config = SolverConfig(
-        device=DigitalAnalogDevice(),
+        device=AnalogDeviceWithDMM(),
         drive_shaping=ds_config,
     )
 
@@ -301,7 +301,7 @@ def test_failed_simulation() -> None:
     ds_config = DriveShapingConfig()
     ds_config.optimized_n_calls = 11
     config = SolverConfig(
-        device=DigitalAnalogDevice(),
+        device=AnalogDeviceWithDMM(),
         drive_shaping=ds_config,
     )
 
@@ -328,7 +328,7 @@ def test_failed_simulation_2() -> None:
     ds_config = DriveShapingConfig()
     ds_config.optimized_n_calls = 11
     config = SolverConfig(
-        device=DigitalAnalogDevice(),
+        device=AnalogDeviceWithDMM(),
         drive_shaping=ds_config,
     )
 
@@ -359,7 +359,7 @@ def test_failed_skopt() -> None:
     ds_config = DriveShapingConfig()
     ds_config.optimized_n_calls = 11
     config = SolverConfig(
-        device=DigitalAnalogDevice(),
+        device=AnalogDeviceWithDMM(),
         drive_shaping=ds_config,
     )
 

--- a/tests/embeddings/test_embedding.py
+++ b/tests/embeddings/test_embedding.py
@@ -117,7 +117,6 @@ def test_correctness_greedy_max_radial_distance_constraint_with_extra_greedy_tra
     )
 
     for device in [AnalogDevice(), AnalogDeviceWithDMM()]:
-        print(f"Device = {device}")
 
         min_distance = 1.0 if normalized else None
 

--- a/tests/embeddings/test_embedding.py
+++ b/tests/embeddings/test_embedding.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 import numpy as np
-from qoolqit.devices import Device, DigitalAnalogDevice, AnalogDevice
+from qoolqit.devices import Device, AnalogDeviceWithDMM, AnalogDevice, DigitalAnalogDevice
 from qubosolver import QUBOInstance
 from qubosolver.config import (
     EmbeddingConfig,
@@ -53,6 +53,7 @@ def test_correctness_greedy_embedder(qubo_instance_for_embedding: QUBOInstance) 
             greedy_traps=qubo_instance_for_embedding.size,
             greedy_spacing=4.0,
         ),
+        device=DigitalAnalogDevice(),
     )
     solver = QuboSolver(qubo_instance_for_embedding, config)
     positions = solver.embedding()
@@ -79,7 +80,7 @@ def test_error_greedy_max_radial_distance_constraint(
 ) -> None:
     assert qubo_instance_for_embedding.size is not None
 
-    for device in [AnalogDevice(), DigitalAnalogDevice()]:
+    for device in [AnalogDevice(), AnalogDeviceWithDMM()]:
         max_radial_distance = device.specs["max_radial_distance"]
         assert max_radial_distance is not None
         greedy_config = SolverConfig(
@@ -105,28 +106,18 @@ def test_correctness_greedy_max_radial_distance_constraint_with_extra_greedy_tra
 ) -> None:
     assert qubo_instance_for_embedding.size is not None
 
-    expected_greedy_positions = [
-        torch.tensor(
-            [
-                [0.0000, 0.0000],
-                [-9.5000, -16.4531],
-                [-19.0000, 0.0000],
-                [-9.5000, 16.4531],
-            ],
-            dtype=torch.float64,
-        ),
-        torch.tensor(
-            [
-                [12.5000, -21.6562],
-                [0.0000, 0.0000],
-                [-25.0000, 0.0000],
-                [-12.5000, -21.6562],
-            ],
-            dtype=torch.float64,
-        ),
-    ]
+    expected = torch.tensor(
+        [
+            [0.0000, 0.0000],
+            [-9.5000, -16.4531],
+            [-19.0000, 0.0000],
+            [-9.5000, 16.4531],
+        ],
+        dtype=torch.float64,
+    )
 
-    for expected, device in zip(expected_greedy_positions, [AnalogDevice(), DigitalAnalogDevice()]):
+    for device in [AnalogDevice(), AnalogDeviceWithDMM()]:
+        print(f"Device = {device}")
 
         min_distance = 1.0 if normalized else None
 

--- a/tests/embeddings/test_greedy.py
+++ b/tests/embeddings/test_greedy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import torch
 import numpy as np
-from qoolqit.devices.device import DigitalAnalogDevice
+from qoolqit.devices.device import AnalogDeviceWithDMM
 
 from qubosolver.algorithms.greedy.greedy import Greedy
 from qubosolver.qubo_types import LayoutType
@@ -77,7 +77,7 @@ def test_triangular_qubo(traps: int, relative_noise: float) -> None:
 
     spacing = 7.0
 
-    device = DigitalAnalogDevice()._device
+    device = AnalogDeviceWithDMM()._device
     C6 = device.interaction_coeff
 
     parameters = {
@@ -138,7 +138,7 @@ def test_square_qubo(traps: int, layout: LayoutType | str, relative_noise: float
 
     spacing = 7.0
 
-    device = DigitalAnalogDevice()._device
+    device = AnalogDeviceWithDMM()._device
     C6 = device.interaction_coeff
 
     parameters = {
@@ -196,7 +196,7 @@ def test_square_qubo(traps: int, layout: LayoutType | str, relative_noise: float
 @pytest.mark.parametrize("relative_noise", [0.0, 0.01, 0.05, -0.01, -0.05])
 def test_too_large_spacing(too_large: str, relative_noise: float) -> None:
 
-    device = DigitalAnalogDevice()._device
+    device = AnalogDeviceWithDMM()._device
     C6 = device.interaction_coeff
 
     # A square layout of size 25 is composed of two concentric squares of side
@@ -300,7 +300,7 @@ def test_too_large_spacing(too_large: str, relative_noise: float) -> None:
 
 def test_max_distance_constraint() -> None:
 
-    device = DigitalAnalogDevice()._device
+    device = AnalogDeviceWithDMM()._device
 
     # A square layout of size 9 is composed of a square of side 2*spacing, plus the origin.
     # With a large enough spacing, the outer corners should be out of range, and thus a

--- a/tests/embeddings/test_greedy_animation.py
+++ b/tests/embeddings/test_greedy_animation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 import torch
-from qoolqit.devices.device import DigitalAnalogDevice
+from qoolqit.devices.device import AnalogDeviceWithDMM
 
 from qubosolver.algorithms.greedy.greedy import Greedy
 from qubosolver.qubo_types import LayoutType
@@ -31,7 +31,7 @@ def _base_params(n: int) -> Dict[str, Any]:
         "layout": LayoutType.TRIANGULAR,
         "traps": n + 4,
         "spacing": 5.0,
-        "device": DigitalAnalogDevice()._device,
+        "device": AnalogDeviceWithDMM()._device,
     }
 
 

--- a/tests/solvers/test_decomposition.py
+++ b/tests/solvers/test_decomposition.py
@@ -8,7 +8,7 @@ import numpy as np
 import random
 from typing import Tuple, List
 
-from qoolqit.devices import DigitalAnalogDevice
+from qoolqit.devices import AnalogDeviceWithDMM, DigitalAnalogDevice
 from qoolqit import Register
 from qubosolver import QUBOInstance
 
@@ -50,6 +50,7 @@ def test_initial_steps_solver(decomposable_qubo: QUBOInstance, use_quantum: bool
         use_quantum=use_quantum,
         decompose=decompose_config,
         embedding=EmbeddingConfig(min_distance=1.0),
+        device=DigitalAnalogDevice(),
     )
     solver = QuboSolver(decomposable_qubo, config)
 
@@ -130,6 +131,7 @@ def test_decomp_solver(decomposable_qubo: QUBOInstance, use_quantum: bool) -> No
         use_quantum=use_quantum,
         decompose=DecompositionConfig(),
         embedding=EmbeddingConfig(min_distance=1.0),
+        device=DigitalAnalogDevice(),
     )
     solver = QuboSolver(decomposable_qubo, config)
 
@@ -186,7 +188,7 @@ def test_compute_distance_interaction_matrix_zero_output() -> None:
 
     neglecting_inter_distance = 15.0
     neglecting_max_coefficient = 1.0
-    device = DigitalAnalogDevice()
+    device = AnalogDeviceWithDMM()
 
     Q = torch.tensor(
         [
@@ -209,7 +211,7 @@ def test_compute_distance_interaction_diagonal() -> None:
 
     neglecting_inter_distance = 15.0
     neglecting_max_coefficient = 1.0
-    device = DigitalAnalogDevice()
+    device = AnalogDeviceWithDMM()
 
     Q = torch.tensor(
         [
@@ -311,6 +313,7 @@ def test_decompose_and_solve_block_qubo(seed: int, dims: Tuple[int]) -> None:
     config = SolverConfig(
         use_quantum=False,
         decompose=DecompositionConfig(decompose_stop_number=2, decompose_break_placement=0),
+        device=DigitalAnalogDevice(),
     )
     solver = QuboSolver(qubo_instance, config)
     assert isinstance(solver._solver, DecomposeQuboSolver)

--- a/tests/test_batch_id.py
+++ b/tests/test_batch_id.py
@@ -154,7 +154,7 @@ def test_quantum_batch_id(
         probabilities = [
             df.set_index("bitstrings")["probs"].get(b, 0.0) for b in expected_solutions
         ]
-        check.greater(max(probabilities), 0.3)
+        check.greater(max(probabilities), 0.4)
 
         for b in expected_solutions:
             if b in df["bitstrings"].values:

--- a/tests/test_batch_id.py
+++ b/tests/test_batch_id.py
@@ -21,6 +21,7 @@ from qubosolver.qubo_types import EmbedderType, DriveType
 from qubosolver.solver import QUBOInstance, QuboSolverQuantum, QUBOSolution
 import qubosolver.io.utils as io_utils
 
+from qoolqit import DigitalAnalogDevice
 from qoolqit.execution import retrieve_remote_job, get_batch_id, job, JobStatus
 from mock.connection import MockConnection
 
@@ -59,7 +60,7 @@ def test_quantum_batch_id(
 
         min_distance = 1.001 if drive_method == DriveType.HEURISTIC else None
 
-        config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing)
+        config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice())
         config.embedding = EmbeddingConfig(
             embedding_method=embedding_method,
             greedy_spacing=7.0,
@@ -151,7 +152,7 @@ def test_quantum_batch_id(
         probabilities = [
             df.set_index("bitstrings")["probs"].get(b, 0.0) for b in expected_solutions
         ]
-        check.greater(max(probabilities), 0.4)
+        check.greater(max(probabilities), 0.3)
 
         for b in expected_solutions:
             if b in df["bitstrings"].values:

--- a/tests/test_batch_id.py
+++ b/tests/test_batch_id.py
@@ -60,7 +60,9 @@ def test_quantum_batch_id(
 
         min_distance = 1.001 if drive_method == DriveType.HEURISTIC else None
 
-        config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice())
+        config = SolverConfig(
+            use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice()
+        )
         config.embedding = EmbeddingConfig(
             embedding_method=embedding_method,
             greedy_spacing=7.0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import pytest
 from typing import Any
 import pytest_check as check
-from pulser.devices import DigitalAnalogDevice as PulserDADevice
 from pulser_simulation import QutipBackendV2
-from qoolqit.devices.device import AnalogDevice
+from qoolqit.devices.device import AnalogDevice, AnalogDeviceWithDMM
 from qubosolver.config import (
     LocalEmulator,
     ClassicalConfig,
@@ -94,7 +93,7 @@ def test_qutip_config_backend(qutip_solver_config: SolverConfig) -> None:
 def test_blade_config(blade_config: SolverConfig) -> None:
     assert blade_config.embedding.embedding_method == EmbedderType.BLADE
     assert (
-        blade_config.device._device == PulserDADevice
+        type(blade_config.device) == AnalogDeviceWithDMM
         and blade_config.embedding.blade_dimensions == [2]
     )
     assert blade_config.embedding.blade_dimensions == [2]
@@ -108,7 +107,7 @@ def test_blade_clear_dimensions_config(
 
 def test_greedy_embedding_config(greedy_embedding_config: SolverConfig) -> None:
     assert greedy_embedding_config.embedding.embedding_method == EmbedderType.GREEDY
-    assert greedy_embedding_config.device._device == PulserDADevice
+    assert type(greedy_embedding_config.device) == AnalogDeviceWithDMM
     assert greedy_embedding_config.embedding.greedy_layout == LayoutType.SQUARE
     assert greedy_embedding_config.embedding.greedy_traps == 10
     assert greedy_embedding_config.embedding.greedy_spacing == 5.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,10 +92,7 @@ def test_qutip_config_backend(qutip_solver_config: SolverConfig) -> None:
 
 def test_blade_config(blade_config: SolverConfig) -> None:
     assert blade_config.embedding.embedding_method == EmbedderType.BLADE
-    assert (
-        type(blade_config.device) == AnalogDeviceWithDMM
-        and blade_config.embedding.blade_dimensions == [2]
-    )
+    assert type(blade_config.device) is AnalogDeviceWithDMM
     assert blade_config.embedding.blade_dimensions == [2]
 
 
@@ -107,7 +104,7 @@ def test_blade_clear_dimensions_config(
 
 def test_greedy_embedding_config(greedy_embedding_config: SolverConfig) -> None:
     assert greedy_embedding_config.embedding.embedding_method == EmbedderType.GREEDY
-    assert type(greedy_embedding_config.device) == AnalogDeviceWithDMM
+    assert type(greedy_embedding_config.device) is AnalogDeviceWithDMM
     assert greedy_embedding_config.embedding.greedy_layout == LayoutType.SQUARE
     assert greedy_embedding_config.embedding.greedy_traps == 10
     assert greedy_embedding_config.embedding.greedy_spacing == 5.0

--- a/tests/test_driveshaping.py
+++ b/tests/test_driveshaping.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 import torch
 import pytest_check as check
+from qoolqit import DigitalAnalogDevice
 from qoolqit.register import Register
 from qoolqit.drive import Drive
 from qubosolver.config import DriveShapingConfig, SolverConfig
@@ -153,12 +154,12 @@ def test_normalized_weights_in_drive(
 
 
 def test_drive_duration_set(dummy_register: Register, simple_qubo_instance: QUBOInstance) -> None:
-    default_config = SolverConfig(use_quantum=True)
+    default_config = SolverConfig(use_quantum=True, device=DigitalAnalogDevice())
     backend = default_config.backend
     shaper = get_drive_shaper(simple_qubo_instance, default_config, backend)
     drive, _ = shaper.generate(dummy_register)
 
-    # DigitalAnalogDevice has a hardcoded duration
+    # AnalogDeviceWithDMM has a hardcoded duration
     check.almost_equal(drive.duration, 1000.0)
 
 
@@ -185,6 +186,7 @@ def test_generate_heuristic_drive_shaper(
     default_config = SolverConfig(
         use_quantum=True,
         drive_shaping=DriveShapingConfig(drive_shaping_method=DriveType.HEURISTIC, dmm=dmm),
+        device=DigitalAnalogDevice(),
     )
     backend = default_config.backend
     shaper = get_drive_shaper(simple_qubo_instance, default_config, backend)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_check as check
 import torch
 
-from qoolqit import Drive, Ramp, Register, Constant
+from qoolqit import Drive, Ramp, Register, Constant, DigitalAnalogDevice
 from qubosolver import QUBOInstance, QUBOSolution
 from qubosolver.qubo_analyzer import QUBOAnalyzer
 from qubosolver.config import (
@@ -307,7 +307,7 @@ def test_quantum_prepostprocessing_2(
 
     instance = QUBOInstance(Q)
 
-    config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing)
+    config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice())
     config.embedding = EmbeddingConfig(
         embedding_method=embedding_method,
         greedy_spacing=0.1,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -307,7 +307,9 @@ def test_quantum_prepostprocessing_2(
 
     instance = QUBOInstance(Q)
 
-    config = SolverConfig(use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice())
+    config = SolverConfig(
+        use_quantum=True, do_preprocessing=preprocessing, device=DigitalAnalogDevice()
+    )
     config.embedding = EmbeddingConfig(
         embedding_method=embedding_method,
         greedy_spacing=0.1,


### PR DESCRIPTION
min_distance defaults to 1.001
device defaults to AnalogDeviceWithDMM

The latter requires qoolqit 1.1.1

DigitalAnalogDevice should not be used. It's kept in tests because some were tuned for it.