### PR TITLE
Bump numpy version to >=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 # always specify a version for each package
 # to maintain consistency
 dependencies = [
-  "numpy",
+  "numpy>=2",
   "torch",
   "scikit-learn",
   "pandas",


### PR DESCRIPTION
Raising the floor to NumPy ≥ 2 simplifies maintenance and CI by reducing the number of old binary wheels / ABI combinations to support, and keeps qubo-solver compatible with the versions that downstream libraries increasingly expect