### PR TITLE
[CI] Shorten CI test matrix for regular PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,6 @@ jobs:
       matrix:
         python-version: ["3.12"]
         use-double-precision: [0, 1]
-        runtime-checks: [0, 1]
     steps:
         - name: Checkout main code and submodules
           uses: actions/checkout@v6
@@ -102,7 +101,7 @@ jobs:
         - name: Perform unit tests
           env:
             USE_DOUBLE_PRECISION: ${{ matrix.use-double-precision }}
-            QUBO_SOLVER_RUNTIME_CHECKS: ${{ matrix.runtime-checks }}
+            QUBO_SOLVER_RUNTIME_CHECKS: 1
           run: |
             uv run --all-extras pytest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    name: Compute Python version matrix
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/')) && '["3.10"]' || '["3.10", "3.11", "3.12"]' }}
+    steps:
+      - run: echo "Computed matrix"
+
   unit_tests:
     name: Unit testing
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ${{ fromJSON(needs.setup.outputs.python-versions) }}
     steps:
         - name: Checkout main code and submodules
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -48,10 +57,11 @@ jobs:
 
   unit_tests_windows:
     name: Unit testing Windows
+    needs: setup
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ${{ fromJSON(needs.setup.outputs.python-versions) }}
     steps:
         - name: Checkout main code and submodules
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Run only Python 3.10 in unit_tests/unit_tests_windows for PRs not coming from a release/* branch, keeping the full 3.10/3.11/3.12 matrix for push/tag/workflow_dispatch and release PRs. The version list is computed once in a new setup job to avoid duplicating the condition across jobs.

Closes #227 