### PR TITLE
Handle negative QUBO coefficients via bit-flip preprocessing

### DIFF
--- a/docs/content/classical/post-and-pre_processing/negative_coefficients.md
+++ b/docs/content/classical/post-and-pre_processing/negative_coefficients.md
@@ -1,0 +1,175 @@
+# Negative coefficient preprocessing
+
+This page explains how to handle negative off-diagonal QUBO coefficients with:
+
+- bit-flip preprocessing;
+- explicit zeroing of remaining negative coefficients.
+
+## Configuration
+
+Negative coefficient preprocessing is controlled from `SolverConfig.do_preprocessing`.
+
+When `do_preprocessing=True`, the solver chains variable-fixing and bit-flip preprocessing
+before solving. If negative off-diagonal coefficients remain afterwards, the quantum solver
+automatically zeros them out (logging a message) before embedding, since the backend cannot
+encode negative interactions. There is no configuration flag to opt out of this fallback or to
+make it raise instead: the `Solver` API always runs the full chain the same way.
+
+!!! note
+    The `Solver` API does not let you run bit-flip preprocessing and zeroing independently of
+    each other, or independently of variable-fixing. If you need that flexibility — for example,
+    to inspect the QUBO after bit-flip preprocessing but before deciding whether to zero it — use
+    the functional API directly, as shown below: `transforms.negative_bitflip.apply` and
+    `transforms.zeroing.apply` can each be called on their own.
+
+## Bit-flip preprocessing
+
+Bit-flip preprocessing searches for a flip vector.
+
+For each variable:
+
+- `flip_vector[i] = 0`: the variable is kept unchanged;
+- `flip_vector[i] = 1`: the variable is complemented.
+
+The transformed QUBO is equivalent to the original problem up to this change of variables.
+
+Internally, the current implementation uses GLPK to select a flip vector that minimizes the remaining negative off-diagonal weight.
+
+The transform lives in `qubosolver.transforms.negative_bitflip`. Calling
+`negative_bitflip.apply` solves the ILP, applies the flips, and returns an `Instance`
+that records the flip vector, status, and metrics.
+
+```python exec="on" source="tabbed-left" session="negative" result="text"
+import json
+from qubosolver import Instance, transforms, matrix, Analyzer
+
+Q = Instance(matrix.tensor(
+    [
+        [1.0, -3.0, -2.0, 1.0],
+        [-3.0, 6.0, 3.0, -1.0],
+        [-2.0, 3.0, 2.0, -1.0],
+        [1.0, -1.0, -1.0, -1.0],
+    ]
+))
+
+reduced = transforms.negative_bitflip.apply(Q, time_limit_s=5.0)
+
+print(f"Flip vector: {reduced.flips}")
+print(f"Bitflip status: {reduced.status}")
+print(f"Bitflip metrics: {json.dumps(reduced.metrics, indent=4)}")
+```
+
+## Classical check
+
+For classical solvers, preprocessing is optional. It can be used to check that the transformed problem gives the same cost after postprocessing.
+
+End-to-end solving goes through the public `Solver` dispatcher, which picks the
+classical or quantum solver from the `SolverConfig`.
+
+```python exec="on" source="tabbed-left" session="negative" result="text"
+from qubosolver import Solver, SolverConfig, solvers
+
+config_without_preprocessing = SolverConfig(
+    use_quantum=False,
+    do_preprocessing=False,
+    activate_trivial_solutions=False,
+)
+
+solution_without_preprocessing = Solver(
+    Q,
+    config_without_preprocessing,
+).solve()
+
+config_with_bitflip = SolverConfig(
+    use_quantum=False,
+    do_preprocessing=True,
+    activate_trivial_solutions=False,
+)
+
+solution_with_bitflip = Solver(
+    Q,
+    config_with_bitflip,
+).solve()
+
+print(f"Best cost without preprocessing: {solution_without_preprocessing[0].cost}")
+print(f"Best cost with bit-flip preprocessing: {solution_with_bitflip[0].cost}")
+```
+
+## Remaining negative coefficients
+
+Bit-flip preprocessing reduces the negative off-diagonal coefficients, but it may not remove all of them.
+
+```python exec="on" source="tabbed-left" session="negative" result="text"
+Q_hard = Instance(matrix.tensor(
+    [
+        [0.0, -2.0, 1.0, 1.0],
+        [-2.0, 0.0, -2.0, 1.0],
+        [1.0, -2.0, 0.0, -2.0],
+        [1.0, 1.0, -2.0, 0.0],
+    ]
+))
+
+reduced_hard = transforms.negative_bitflip.apply(Q_hard, time_limit_s=5.0)
+
+print(f"Bitflip status: {reduced_hard.status}")
+print(f"Bitflip metrics: {json.dumps(reduced_hard.metrics, indent=4)}")
+```
+
+## Zeroing
+
+If negative off-diagonal coefficients remain after bit-flip preprocessing, they can be
+explicitly set to zero with `zeroing.apply`, applied on top of the bit-flip result.
+
+This makes the QUBO compatible with the quantum solver, but it changes the QUBO objective. It
+should therefore be used only when this approximation is acceptable.
+
+`zeroing.apply` returns a new `Instance`; it does not modify its argument in place.
+
+```python exec="on" source="tabbed-left" session="negative" result="text"
+zeroed_hard = transforms.zeroing.apply(reduced_hard)
+
+print(f"Zeroed edges:\n{zeroed_hard.zeroed_edges}")
+print(f"Negative matrix:\n{zeroed_hard.negative_matrix}")
+```
+
+## Quantum solving
+
+When using the `Solver` API with `use_quantum=True`, the final QUBO is checked after
+preprocessing. If negative off-diagonal coefficients remain, the quantum solver zeros them out
+automatically (logging a message) so the QUBO can be embedded and solved with the selected
+backend — there is no separate flag to request this.
+
+```python exec="on" source="tabbed-left" session="negative" result="text"
+from qoolqit import AnalogDeviceWithDMM
+from pulser_simulation import QutipBackendV2
+
+from qubosolver import LocalEmulator
+
+config_quantum = SolverConfig(
+    use_quantum=True,
+    do_preprocessing=True,
+    activate_trivial_solutions=False,
+)
+
+quantum_solution = Solver(Q_hard, config_quantum).solve()
+
+print(f"Quantum solution:\n{Analyzer(quantum_solution).df}")
+```
+
+To control bit-flip preprocessing and zeroing independently — for example to zero a QUBO without
+running bit-flip preprocessing first, or to inspect intermediate results — call
+`transforms.negative_bitflip.apply` and `transforms.zeroing.apply` directly, as in the sections
+above, and pass the resulting `Instance` to `embedding`/`drive_shaping`/`solvers` yourself instead
+of going through `Solver`.
+
+## Notes
+
+Bit-flip preprocessing is the preferred approach because it preserves the QUBO objective up to a variable transformation.
+
+Zeroing should be used only when this approximation is acceptable.
+
+The current bit-flip implementation uses GLPK to compute the flip vector exactly. This is useful for validation and small QUBOs, but it is not expected to scale to large industrial instances.
+
+Future versions should replace this exact GLPK step with an efficient classical heuristic for selecting good flip vectors at larger scale.
+
+Future work should also add a dedicated method to represent negative interactions directly during the quantum resolution.

--- a/docs/tutorial/10-functional-pipeline.ipynb
+++ b/docs/tutorial/10-functional-pipeline.ipynb
@@ -252,7 +252,7 @@
     "print(f\"Embedding with {embedding_method} method...\")\n",
     "if embedding_method == \"blade\":\n",
     "    blade_config = embedding.blade.Config(device=device)\n",
-    "    register = embedding.blade.embed(effective_qubo, config=blade_config, normalize=True)\n",
+    "    register = embedding.blade.embed(effective_qubo, config=blade_config)\n",
     "elif embedding_method == \"greedy\":\n",
     "    greedy_config = embedding.greedy.Config(traps=100)\n",
     "    register = embedding.greedy.embed(effective_qubo, device, config=greedy_config)\n",

--- a/docs/tutorial/12-negative-coefficients-preprocessing.ipynb
+++ b/docs/tutorial/12-negative-coefficients-preprocessing.ipynb
@@ -1,0 +1,684 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dffbb83a",
+   "metadata": {},
+   "source": [
+    "# Negative coefficient preprocessing for QUBO solving\n",
+    "\n",
+    "This tutorial shows how to handle negative off-diagonal coefficients using bit-flip preprocessing and zeroing.\n",
+    "Bit-flip preprocessing keeps the problem equivalent up to a variable transformation.\n",
+    "Zeroing is different: it changes the QUBO. It's automatically performed (and logged) by the quantum solver when preprocessing is not enough, since the solver only handles non-negative off-diagonal coefficients. When using the functional API, zeroing has to be applied explicitly. Embedders, on the other hand, raise an error if any negative off-diagonal coefficient is detected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ef3bfab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/.venv/lib/python3.10/site-packages/qoolqit/execution/backends.py:10: DeprecationWarning: This package is replaced by pasqal-cloud (https://pypi.org/project/pasqal-cloud/) and is going to be removed in the future.\n",
+      "  from pulser_pasqal.backends import EmuFreeBackendV2, RemoteEmulatorBackend\n",
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/_waveforms.py:8: DeprecationWarning: Constant is deprecated and will be removed in v1.4. Use the equivalent ConstantWaveform instead.\n",
+      "  from qoolqit import Constant as ConstantWaveform\n",
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/_waveforms.py:8: DeprecationWarning: Constant is deprecated and will be removed in v1.4. Use the equivalent ConstantWaveform instead.\n",
+      "  from qoolqit import Constant as ConstantWaveform\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import math\n",
+    "\n",
+    "import qoolqit\n",
+    "\n",
+    "from qubosolver import (\n",
+    "    Analyzer,\n",
+    "    Instance,\n",
+    "    Solution,\n",
+    "    Solver,\n",
+    "    LocalEmulator,\n",
+    "    SolverConfig,\n",
+    "    solvers,\n",
+    "    transforms,\n",
+    "    drive_shaping,\n",
+    "    embedding,\n",
+    "    matrix,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c80206c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_solution(name, solution):\n",
+    "    print(name)\n",
+    "    df = Analyzer(solution).df\n",
+    "    df[\"Trivial\"] = df[\"bitstrings\"].apply(lambda b: len(set(b)) == 1)\n",
+    "    print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab20633c",
+   "metadata": {},
+   "source": [
+    "## 1. A QUBO with negative off-diagonal coefficients\n",
+    "\n",
+    "We start with a small QUBO that contains negative off-diagonal coefficients.\n",
+    "\n",
+    "The example is chosen so that:\n",
+    "\n",
+    "- the solution is not trivial;\n",
+    "- bit-flip preprocessing can remove all negative off-diagonal coefficients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0e4cccf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QUBO:\n",
+      "tensor([[ 1., -3., -2.,  1.],\n",
+      "        [-3.,  6.,  3., -1.],\n",
+      "        [-2.,  3.,  2., -1.],\n",
+      "        [ 1., -1., -1., -1.]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "instance = Instance(\n",
+    "    matrix.tensor(\n",
+    "    [\n",
+    "        [1.0, -3.0, -2.0, 1.0],\n",
+    "        [-3.0, 6.0, 3.0, -1.0],\n",
+    "        [-2.0, 3.0, 2.0, -1.0],\n",
+    "        [1.0, -1.0, -1.0, -1.0],\n",
+    "    ])\n",
+    ")\n",
+    "\n",
+    "print(f\"QUBO:\\n{instance.matrix}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac2986be",
+   "metadata": {},
+   "source": [
+    "## 2. Bit-flip preprocessing\n",
+    "\n",
+    "The bit-flip preprocessing chooses which binary variables should be complemented.\n",
+    "\n",
+    "For each variable:\n",
+    "\n",
+    "- if `flip_vector[i] = 0`, the variable is kept unchanged;\n",
+    "- if `flip_vector[i] = 1`, the variable is replaced by its complement.\n",
+    "\n",
+    "Internally, the flip vector is selected by solving a variant of a max-cut problem with GLPK:\n",
+    "flipping a variable inverts the sign of every coefficient linking it to an unflipped variable, so\n",
+    "choosing the flip set is equivalent to choosing which \"side\" of a cut each variable falls on.\n",
+    "\n",
+    "The objective is to minimize the total weight of negative off-diagonal coefficients remaining after the flips.\n",
+    "\n",
+    "The transform lives in `qubosolver.transforms.negative_bitflip`. Calling `negative_bitflip.apply` solves the ILP, applies the flips, and returns an `Instance` that records the flip vector, status, and metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d1c79ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flip vector: tensor([1, 0, 0, 1], dtype=torch.int8)\n",
+      "Bitflip status: OPTIMAL\n",
+      "Bitflip metrics: {\n",
+      "    \"n_edges\": 6,\n",
+      "    \"neg_count_before\": 4,\n",
+      "    \"neg_count_after\": 0,\n",
+      "    \"neg_count_reduction_pct\": 100.0,\n",
+      "    \"neg_weight_before\": 7.0,\n",
+      "    \"neg_weight_after\": 0.0,\n",
+      "    \"neg_weight_reduction_pct\": 100.0,\n",
+      "    \"objective_value\": -7.0\n",
+      "}\n",
+      "\n",
+      "Preprocessed QUBO:\n",
+      "tensor([[-3.,  3.,  2.,  1.],\n",
+      "        [ 3., -2.,  3.,  1.],\n",
+      "        [ 2.,  3., -4.,  1.],\n",
+      "        [ 1.,  1.,  1., -1.]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=5.0)\n",
+    "\n",
+    "print(f\"Flip vector: {flipped_instance.flips}\")\n",
+    "print(f\"Bitflip status: {flipped_instance.status}\")\n",
+    "print(f\"Bitflip metrics: {json.dumps(flipped_instance.metrics, indent=4)}\")\n",
+    "\n",
+    "print(f\"\\nPreprocessed QUBO:\\n{flipped_instance.matrix}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1b3581",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flip vector: tensor([1, 0, 0, 1], dtype=torch.int8)\n",
+      "x_0 = 1 - y_0\n",
+      "x_1 = y_1\n",
+      "x_2 = y_2\n",
+      "x_3 = 1 - y_3\n"
+     ]
+    }
+   ],
+   "source": [
+    "flip_vector = flipped_instance.flips\n",
+    "\n",
+    "print(f\"Flip vector: {flip_vector}\")\n",
+    "\n",
+    "for i, flip in enumerate(flip_vector.tolist()):\n",
+    "    if flip == 0:\n",
+    "        print(f\"x_{i} = y_{i}\")\n",
+    "    else:\n",
+    "        print(f\"x_{i} = 1 - y_{i}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "191ca55e",
+   "metadata": {},
+   "source": [
+    "## 3. Classical sanity check with brute force\n",
+    "\n",
+    "We solve the same QUBO exhaustively:\n",
+    "\n",
+    "1. without preprocessing;\n",
+    "2. with bit-flip preprocessing.\n",
+    "\n",
+    "Bit-flip preprocessing is an equivalent transformation up to a change of variables, so the\n",
+    "returned solution has the same objective value in the original QUBO space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12d56e95",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution without preprocessing:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       1011   -2.0       1    1.0    False\n"
+     ]
+    }
+   ],
+   "source": [
+    "solution_without_preprocessing = solvers.brute_force(instance)\n",
+    "\n",
+    "print_solution(\"Solution without preprocessing:\", solution_without_preprocessing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51af081d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution with bit-flip preprocessing:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       1011   -2.0       1    1.0    False\n"
+     ]
+    }
+   ],
+   "source": [
+    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=5.0)\n",
+    "flipped_solution = solvers.brute_force(flipped_instance)\n",
+    "solution_with_bitflip = transforms.negative_bitflip.unapply(flipped_solution, flipped_instance)\n",
+    "\n",
+    "print_solution(\"Solution with bit-flip preprocessing:\", solution_with_bitflip)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f4d88b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Same best cost: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "same_best_cost = math.isclose(solution_without_preprocessing[0].cost, solution_with_bitflip[0].cost)\n",
+    "print(f\"\\nSame best cost: {same_best_cost}\")\n",
+    "assert same_best_cost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc4c1682",
+   "metadata": {},
+   "source": [
+    "## 4. When bit-flip preprocessing is not enough\n",
+    "\n",
+    "Bit-flip preprocessing does not always remove all negative coefficients.\n",
+    "\n",
+    "In the next example, bit-flip preprocessing reduces the negative weight, but one negative coefficient remains."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41eea901",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QUBO:\n",
+      "tensor([[ 0., -2.,  1.,  1.],\n",
+      "        [-2.,  0., -2.,  1.],\n",
+      "        [ 1., -2.,  0., -2.],\n",
+      "        [ 1.,  1., -2.,  0.]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "hard_instance = Instance(\n",
+    "    matrix.tensor(\n",
+    "    [\n",
+    "        [0.0, -2.0, 1.0, 1.0],\n",
+    "        [-2.0, 0.0, -2.0, 1.0],\n",
+    "        [1.0, -2.0, 0.0, -2.0],\n",
+    "        [1.0, 1.0, -2.0, 0.0],\n",
+    "    ])\n",
+    ")\n",
+    "\n",
+    "print(f\"QUBO:\\n{hard_instance.matrix}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "065c6d61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Brute force solution:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       1111   -6.0       1    0.1     True\n",
+      "1      0       1110   -6.0       1    0.1    False\n",
+      "2      0       0111   -6.0       1    0.1    False\n",
+      "3      0       0011   -4.0       1    0.1    False\n",
+      "4      0       1100   -4.0       1    0.1    False\n",
+      "5      0       0110   -4.0       1    0.1    False\n",
+      "6      0       1000    0.0       1    0.1    False\n",
+      "7      0       1101    0.0       1    0.1    False\n",
+      "8      0       1011    0.0       1    0.1    False\n",
+      "9      0       0000    0.0       1    0.1     True\n"
+     ]
+    }
+   ],
+   "source": [
+    "brute_force_solution = solvers.brute_force(hard_instance, max_bitstrings=10)\n",
+    "print_solution(\"Brute force solution:\", brute_force_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68d449ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flip vector: tensor([1, 0, 1, 0], dtype=torch.int8)\n",
+      "Bitflip status: OPTIMAL\n",
+      "Bitflip metrics: {\n",
+      "    \"n_edges\": 6,\n",
+      "    \"neg_count_before\": 3,\n",
+      "    \"neg_count_after\": 1,\n",
+      "    \"neg_count_reduction_pct\": 66.66666666666667,\n",
+      "    \"neg_weight_before\": 6.0,\n",
+      "    \"neg_weight_after\": 1.0,\n",
+      "    \"neg_weight_reduction_pct\": 83.33333333333333,\n",
+      "    \"objective_value\": -5.0\n",
+      "}\n",
+      "\n",
+      "Preprocessed QUBO without zeroing:\n",
+      "tensor([[-2.,  2.,  1., -1.],\n",
+      "        [ 2., -8.,  2.,  1.],\n",
+      "        [ 1.,  2., -2.,  2.],\n",
+      "        [-1.,  1.,  2., -2.]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "flipped_hard_instance = transforms.negative_bitflip.apply(hard_instance, time_limit_s=5.0)\n",
+    "\n",
+    "print(f\"Flip vector: {flipped_hard_instance.flips}\")\n",
+    "print(f\"Bitflip status: {flipped_hard_instance.status}\")\n",
+    "print(f\"Bitflip metrics: {json.dumps(flipped_hard_instance.metrics, indent=4)}\")\n",
+    "\n",
+    "print(f\"\\nPreprocessed QUBO without zeroing:\\n{flipped_hard_instance.matrix}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2301b0f7",
+   "metadata": {},
+   "source": [
+    "## 5. Explicit zeroing of remaining negative coefficients\n",
+    "\n",
+    "If negative off-diagonal coefficients remain after bit-flip preprocessing, they can be explicitly zeroed out with `transforms.zeroing.apply`, applied on top of the bit-flip result.\n",
+    "\n",
+    "This makes the QUBO compatible with the quantum backend, but it changes the QUBO objective. It should therefore be used only when this approximation is acceptable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df6c4de1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Expected error, embedding rejects negative off-diagonal coefficients: QUBOs with negative off-diagonal coefficients cannot be embedded.\n",
+      "\n",
+      "Preprocessed QUBO with zeroing:\n",
+      "tensor([[-2.,  2.,  1.,  0.],\n",
+      "        [ 2., -8.,  2.,  1.],\n",
+      "        [ 1.,  2., -2.,  2.],\n",
+      "        [ 0.,  1.,  2., -2.]])\n",
+      "\n",
+      "Quantum Solution with zeroing:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       0101   -8.0     942  0.942    False\n",
+      "1      0       0100   -8.0      21  0.021    False\n",
+      "2      0       0110   -6.0      11  0.011    False\n",
+      "3      0       1101   -6.0       5  0.005    False\n",
+      "4      0       1100   -6.0       1  0.001    False\n",
+      "5      0       1001   -4.0       2  0.002    False\n",
+      "6      0       1010   -2.0      14  0.014    False\n",
+      "7      0       1110   -2.0       4  0.004    False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/heuristic.py:119: DeprecationWarning: Interpolated is deprecated and will be removed in v1.4. Use the equivalent InterpolatedWaveform instead.\n",
+      "  amp_wave = qoolqit.Interpolated(\n",
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/heuristic.py:125: DeprecationWarning: Interpolated is deprecated and will be removed in v1.4. Use the equivalent InterpolatedWaveform instead.\n",
+      "  det_wave = qoolqit.Interpolated(\n"
+     ]
+    }
+   ],
+   "source": [
+    "device = qoolqit.AnalogDeviceWithDMM()\n",
+    "emulator = LocalEmulator()\n",
+    "\n",
+    "# Demonstrate the embedder's guard: embedding a QUBO that still has negative\n",
+    "# off-diagonal coefficients raises, instead of silently producing a wrong register.\n",
+    "try:\n",
+    "    register = embedding.greedy.embed(flipped_hard_instance, device)\n",
+    "except ValueError as e:\n",
+    "    print(f\"\\nExpected error, embedding rejects negative off-diagonal coefficients: {e}\")\n",
+    "\n",
+    "zeroed_hard_instance = transforms.zeroing.apply(flipped_hard_instance)\n",
+    "print(f\"\\nPreprocessed QUBO with zeroing:\\n{zeroed_hard_instance.matrix}\")\n",
+    "\n",
+    "register = embedding.greedy.embed(zeroed_hard_instance, device)\n",
+    "drive = drive_shaping.heuristic.build_drive(zeroed_hard_instance, register, device=device, dmm=True)\n",
+    "job = solvers.analog_quantum_sample(register, drive, emulator, device)\n",
+    "zeroed_hard_quantum_solution = Solution.from_results(job.results(), instance=zeroed_hard_instance)\n",
+    "print_solution(\"\\nQuantum Solution with zeroing:\", zeroed_hard_quantum_solution)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fceb6b4b",
+   "metadata": {},
+   "source": [
+    "The solution obtained is defined over the zeroed, flipped QUBO's variables. To recover a solution over the *original* QUBO's variables, both transforms must be undone — in the reverse order they were applied: first `zeroing.unapply`, then `negative_bitflip.unapply`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b7853a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Final Quantum Solution:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       1111   -6.0     942  0.942     True\n",
+      "1      0       1110   -6.0      21  0.021    False\n",
+      "2      0       1100   -4.0      11  0.011    False\n",
+      "3      0       0111   -6.0       5  0.005    False\n",
+      "4      0       0110   -4.0       1  0.001    False\n",
+      "5      0       0011   -4.0       2  0.002    False\n",
+      "6      0       0000    0.0      14  0.014     True\n",
+      "7      0       0100    0.0       4  0.004    False\n"
+     ]
+    }
+   ],
+   "source": [
+    "flipped_hard_quantum_solution = transforms.zeroing.unapply(zeroed_hard_quantum_solution, zeroed_hard_instance)\n",
+    "hard_quantum_solution = transforms.negative_bitflip.unapply(flipped_hard_quantum_solution, flipped_hard_instance)\n",
+    "\n",
+    "print_solution(\"\\nFinal Quantum Solution:\", hard_quantum_solution)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23a42da5",
+   "metadata": {},
+   "source": [
+    "## 6. Quantum solver behavior\n",
+    "\n",
+    "In the `Solver` API, `config.do_preprocessing` controls whether bit-flip preprocessing runs before solving.\n",
+    "\n",
+    "If negative off-diagonal coefficients remain after preprocessing, the quantum solver zeros them out automatically (and logs a message) before embedding, since the backend cannot encode negative interactions. It will also log a warning if negative off-diagonal coefficients are detected and preprocessing is not enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ad54d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:qubosolver.solvers.solver:Negative off-diagonal coefficients detected. Without preprocessing, this instance will be embedded via automatic zeroing (an approximation). Set config.do_preprocessing=True to try bit-flip preprocessing instead, which is likely to give better results.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "\n",
+    "config_quantum_no_preprocessing = SolverConfig(\n",
+    "    use_quantum=True,\n",
+    "    do_preprocessing=False,\n",
+    "    activate_trivial_solutions=False,\n",
+    "    do_postprocessing=False,\n",
+    ")\n",
+    "\n",
+    "# Preprocessing is disabled: constructing the solver only warns, it does not raise.\n",
+    "quantum_solver = Solver(hard_instance, config_quantum_no_preprocessing)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba59bff5",
+   "metadata": {},
+   "source": [
+    "Now we enable preprocessing.\n",
+    "\n",
+    "Bit-flip preprocessing reduces the negative coefficients first. Any coefficient it cannot remove is zeroed automatically before the resulting QUBO is passed to the quantum backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec1e45c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:qubosolver.solvers.solver:Bit-flip preprocessing could not remove all negative off-diagonal coefficients; zeroing the remainder as an approximation before embedding.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Quantum solution bitstrings:\n",
+      "  labels bitstrings  costs  counts  probs  Trivial\n",
+      "0      0       1111   -6.0     956  0.956     True\n",
+      "1      0       1110   -6.0      18  0.018    False\n",
+      "2      0       0111   -6.0       3  0.003    False\n",
+      "3      0       0011   -4.0       4  0.004    False\n",
+      "4      0       1100   -4.0       8  0.008    False\n",
+      "5      0       0110   -4.0       2  0.002    False\n",
+      "6      0       0000    0.0       4  0.004     True\n",
+      "7      0       0100    0.0       5  0.005    False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/heuristic.py:119: DeprecationWarning: Interpolated is deprecated and will be removed in v1.4. Use the equivalent InterpolatedWaveform instead.\n",
+      "  amp_wave = qoolqit.Interpolated(\n",
+      "/home/bussy/work/qubo-solver.git/negative-coefficients-bitflip-preprocessing/qubosolver/drive_shaping/heuristic.py:125: DeprecationWarning: Interpolated is deprecated and will be removed in v1.4. Use the equivalent InterpolatedWaveform instead.\n",
+      "  det_wave = qoolqit.Interpolated(\n"
+     ]
+    }
+   ],
+   "source": [
+    "config_quantum = SolverConfig(\n",
+    "    use_quantum=True,\n",
+    "    do_preprocessing=True,\n",
+    "    activate_trivial_solutions=False,\n",
+    "    do_postprocessing=False,\n",
+    ")\n",
+    "\n",
+    "quantum_solution = Solver(hard_instance, config_quantum).solve()\n",
+    "\n",
+    "print_solution(\"Quantum solution bitstrings:\", quantum_solution)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5173439",
+   "metadata": {},
+   "source": [
+    "### Note on the quantum result\n",
+    "\n",
+    "The quantum solution returned here is not necessarily the optimal solution of the original QUBO.\n",
+    "\n",
+    "In this example, the quantum solver runs on a QUBO where the remaining negative off-diagonal coefficients have been set to zero. This makes the problem compatible with the quantum backend, but it also changes the objective optimized by the quantum dynamics.\n",
+    "\n",
+    "The returned bitstrings are then evaluated on the original QUBO, which explains why the final costs should be interpreted as heuristic results.\n",
+    "\n",
+    "Future work aims to go beyond this approximation by adding a dedicated method to encode negative interactions during the quantum resolution itself, in addition to the bit-flip preprocessing that already reduces them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68f883a7",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Bit-flip preprocessing provides a practical way to reduce or remove negative off-diagonal QUBO coefficients before quantum solving.\n",
+    "\n",
+    "It works by selecting a flip vector with GLPK. The flip vector indicates which binary variables should be complemented, and the transformed QUBO is equivalent to the original problem up to this variable change.\n",
+    "\n",
+    "In this tutorial, GLPK is used to compute the flip vector exactly on small QUBOs. This is useful for validation and demonstration, but it is not expected to scale to large industrial instances. Future versions should replace this exact GLPK step with an efficient classical heuristic for selecting good flip vectors at larger scale.\n",
+    "\n",
+    "When bit-flip preprocessing removes all negative off-diagonal coefficients, the QUBO can be passed directly to the quantum solver.\n",
+    "\n",
+    "When some negative coefficients remain, the quantum solver falls back to `transforms.zeroing` automatically. This makes the QUBO compatible with the quantum backend, but it is an approximation because it changes the QUBO objective.\n",
+    "\n",
+    "Future work should also add a dedicated method to represent negative interactions directly during the quantum resolution, going beyond the zeroing approximation used today."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qubo-solver (3.10.19)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - Pre and Post Processing:
       - Pre-processing: content/classical/post-and-pre_processing/preprocessing.md
       - Post-processing: content/classical/post-and-pre_processing/postprocessing.md
+      - Negative coefficients: content/classical/post-and-pre_processing/negative_coefficients.md
 
   - Tutorials:
     - A tour of QUBO: tutorial/00-a-tour-of-qubo.ipynb
@@ -39,6 +40,7 @@ nav:
     - Classical heuristics: tutorial/07-classical-heuristics.ipynb
     - Qubo Analyzer: tutorial/08-qubo_analyzer.ipynb
     - Solving with decomposition: tutorial/09-decomposition.ipynb
+    - Negative coefficients preprocessing: tutorial/12-negative-coefficients-preprocessing.ipynb
 
   - API:
     - qubosolver: api/qubosolver.md
@@ -106,6 +108,8 @@ markdown_extensions:
     generic: true
 - pymdownx.highlight:
     anchor_linenums: true
+- pymdownx.tabbed:
+      alternate_style: true
 - pymdownx.inlinehilite
 - pymdownx.snippets
 - pymdownx.superfences

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "seaborn",
   "scikit-optimize",
   "cplex",
+  "swiglpk>=5.0.13",
   "pydantic>=2",
   "qoolqit[extras]>=1.1.1", # The version in .pre-commit-config.yaml must match
   "shapely",

--- a/qubosolver/embedding/_embedder.py
+++ b/qubosolver/embedding/_embedder.py
@@ -92,7 +92,7 @@ class BLaDEmbedder(_BaseEmbedder):
             dimensions=tuple(embed_config.blade_dimensions),
             max_min_dist_ratio=max_min_dist_ratio,
         )
-        return blade.embed(self.instance, config=config, normalize=False)
+        return blade.embed(self.instance, config=config)
 
 
 class GreedyEmbedder(_BaseEmbedder):

--- a/qubosolver/embedding/blade.py
+++ b/qubosolver/embedding/blade.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TypeAlias
 
 from qubosolver import Instance
+from qubosolver.transforms.negative_bitflip import _has_negative_offdiagonal
 from qoolqit import Register
 from qoolqit.embedding import Blade, BladeConfig
 
@@ -34,7 +35,6 @@ def embed(
     instance: Instance,
     *,
     config: Config = Config(),
-    normalize: bool = True,
 ) -> Register:
     """Embed a QUBO instance using the BLaDE algorithm.
 
@@ -48,17 +48,14 @@ def embed(
         config: BLaDE configuration controlling the optimisation (number of
             steps per round, initial atom positions, dimension sequence,
             maximum allowed ratio of radial to minimum distance, etc.).
-        normalize: If ``True``, rescale the final atom coordinates so that the
-            minimum inter-atom distance is exactly ``1.0001`` — the
-            smallest separation accepted by normalized Pasqal devices.
 
     Returns:
         A register mapping each atom label to its 2-D position, with atom positions determined by BLaDE.
     """
+    if _has_negative_offdiagonal(instance.matrix):
+        raise ValueError("QUBOs with negative off-diagonal coefficients cannot be embedded.")
     _blade = Blade(config)
     graph = _blade.embed(instance.matrix.numpy())
-    if normalize:
-        graph.rescale_coords(spacing=1.0001)
 
     register = Register({str(i): coord for (i, coord) in enumerate(graph.coords.values())})
 

--- a/qubosolver/embedding/greedy.py
+++ b/qubosolver/embedding/greedy.py
@@ -21,6 +21,7 @@ import qoolqit
 
 from ._algorithms import greedy
 from qubosolver import Instance, LayoutType, EmbeddingConfig
+from qubosolver.transforms.negative_bitflip import _has_negative_offdiagonal
 
 
 @dataclass
@@ -46,13 +47,13 @@ class Config:
     """
 
     traps: int | Literal["device"] = "device"
-    max_possible_term: float | tuple[Literal["factor"], float] = 1.0
+    max_possible_term: float | tuple[Literal["factor"], float] = ("factor", 1.0)
     layout: LayoutType = LayoutType.TRIANGULAR
     draw_steps: bool = False
     animation_save_path: pathlib.Path | None = None
     max_min_dist_ratio: float | Literal["device"] = "device"
 
-    def update_from_device(self, device: qoolqit.Device) -> None:
+    def _update_from_device(self, device: qoolqit.Device) -> None:
         """Resolve the ``"device"`` sentinels in-place from device constraints.
 
         When ``traps`` is ``"device"`` (auto), resolves it via
@@ -194,7 +195,10 @@ def embed(
         ValueError: If the resolved trap count is less than ``instance.size``
             (i.e. there are not enough trap sites for all QUBO variables).
     """
-    config.update_from_device(device)
+    if _has_negative_offdiagonal(instance.matrix):
+        raise ValueError("QUBOs with negative off-diagonal coefficients cannot be embedded.")
+
+    config._update_from_device(device)
     assert isinstance(config.traps, int)  # nosec B101
     assert isinstance(config.max_min_dist_ratio, float)  # nosec B101
 

--- a/qubosolver/solvers/__init__.py
+++ b/qubosolver/solvers/__init__.py
@@ -13,6 +13,7 @@ from qubosolver.solvers.classical.cplex import cplex
 from qubosolver.solvers.classical.tabu_search import tabu_search
 from qubosolver.solvers.classical.simulated_annealing import simulated_annealing
 from qubosolver.solvers.classical.random import random_solutions
+from qubosolver.solvers.classical.brute_force import brute_force
 from qubosolver.solvers.solver import Solver, QuboSolver
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "tabu_search",
     "simulated_annealing",
     "random_solutions",
+    "brute_force",
     "Solver",
     "QuboSolver",
 ]

--- a/qubosolver/solvers/_basesolver.py
+++ b/qubosolver/solvers/_basesolver.py
@@ -52,18 +52,6 @@ class BaseSolver(ABC):
         self.backend = self.config.backend
         self.device = self.config.device
 
-    @property
-    def n_fixed_variables_preprocessing(self) -> int:
-        """Number of variables fixed during preprocessing.
-
-        Returns:
-            The count of fixed variables, or 0 if no preprocessing was applied.
-        """
-        if isinstance(self.instance, transforms.variable_fixing.Instance):
-            return self.instance.n_fixed_indices
-        else:
-            return 0
-
     @abstractmethod
     def solve(self) -> Solution:
         """
@@ -192,18 +180,26 @@ class BaseSolver(ABC):
             _solver.instance = self.instance
 
     def preprocess(self) -> None:
-        """Apply variable-fixing preprocessing to reduce the problem size.
+        """Apply preprocessing to reduce the problem size and handle negative interactions.
+
+        Runs variable-fixing first, then GLPK bit-flip preprocessing
+        to remove negative off-diagonal coefficients.
 
         This method is a no-op when ``config.do_preprocessing`` is ``False``.
         """
-        if self.config.do_preprocessing:
-            self._update_instance(transforms.variable_fixing.apply_recursively(self.instance))
+        if not self.config.do_preprocessing:
+            return
+
+        instance: Instance = transforms.variable_fixing.apply_recursively(self.instance)
+        instance = transforms.negative_bitflip.apply(instance)
+        assert isinstance(instance, transforms.negative_bitflip.Instance)
+        self._update_instance(instance)
 
     def post_process_fixation(self, solution: Solution) -> Solution:
         """Restore fixed variables and recover a solution over the original QUBO.
 
-        Reverses the variable-fixing applied by [`preprocess`][]: re-inserts
-        the fixed variable values into *solution*.
+        Reverses the preprocessing applied by [`preprocess`][]: first undoes any
+        bit flips, then re-inserts the fixed variable values into *solution*.
 
         Returns *solution* unchanged when ``config.do_preprocessing`` is
         ``False``.
@@ -219,6 +215,13 @@ class BaseSolver(ABC):
         # Means that preprocessing was not applied
         if not self.config.do_preprocessing:
             return solution
+
+        # Unwind the preprocessing layers in reverse: bit flips, then
+        # variable fixing. Bit-flip and fixing each remap the solution.
+        assert isinstance(self.instance, transforms.negative_bitflip.Instance)  # nosec B101
+        flipped_instance = self.instance
+        solution = transforms.negative_bitflip.unapply(solution, flipped_instance)
+        self._update_instance(flipped_instance._parent_instance)
 
         assert isinstance(self.instance, transforms.variable_fixing.Instance)  # nosec B101
         new_solution = transforms.variable_fixing.unapply(solution, self.instance)

--- a/qubosolver/solvers/classical/brute_force.py
+++ b/qubosolver/solvers/classical/brute_force.py
@@ -1,0 +1,111 @@
+"""Exact brute-force QUBO solver by exhaustive enumeration.
+
+Enumerates the ``2^n`` binary assignments of an ``n``-variable QUBO, evaluates
+``x^T Q x`` for each, and returns the ``max_bitstrings`` lowest-cost ones.  This
+is exact but scales exponentially in ``n``; it is meant for small instances,
+validation, and as a ground-truth reference for other solvers.
+
+Enumeration proceeds in fixed-size batches so peak memory stays bounded and a
+wall-clock ``time_limit`` can interrupt it between batches.  When the limit is
+reached the best assignments found so far are returned, so the result is a valid
+(possibly non-optimal) solution rather than an error.
+
+This solver is intentionally **not** wired into the object-oriented
+[`Solver`][qubosolver.solvers.Solver] dispatcher; call `brute_force`
+directly.
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+from qubosolver.types import Bitstrings, Instance, Solution, Vectori, bitstrings, vector, vectori
+from qubosolver.utils import _costs
+
+# Number of assignments evaluated per batch. Caps peak memory at roughly
+# _BATCH_SIZE * n bytes for the bit matrix regardless of the total 2^n space.
+_BATCH_SIZE = 1 << 16
+
+
+def _decode_bits(indices: Vectori, n: int) -> Bitstrings:
+    """Decode integer indices into their ``n``-bit binary representations.
+
+    Bit ``j`` of variable position ``j`` is taken from the corresponding bit of
+    the index, most-significant bit first, so index ``0`` maps to all-zeros.
+
+    Args:
+        indices: 1-D integer tensor of assignment indices in ``[0, 2^n)``.
+        n: Number of variables (bit width).
+
+    Returns:
+        A ``(len(indices), n)`` bitstrings tensor.
+    """
+    shifts = torch.arange(n - 1, -1, -1, device=indices.device)
+    return bitstrings.from_torch((indices.unsqueeze(1) >> shifts) & 1)
+
+
+def brute_force(
+    instance: Instance,
+    *,
+    max_bitstrings: int = 1,
+    time_limit: float = float("inf"),
+) -> Solution:
+    """Solve a QUBO exactly by enumerating all ``2^n`` binary assignments.
+
+    Evaluates every assignment's cost and returns the ``max_bitstrings``
+    lowest-cost ones, sorted by ascending cost.  Enumeration is batched; when
+    ``time_limit`` elapses, the best assignments found so far are returned.
+
+    Args:
+        instance: The QUBO instance to solve.
+        max_bitstrings: Number of lowest-cost bitstrings to return.  The result
+            may contain fewer when ``2^n < max_bitstrings``.
+        time_limit: Wall-clock budget in seconds.  Enumeration stops between
+            batches once the budget is exhausted and returns the best solutions
+            found so far.  Defaults to ``float("inf")`` (no limit).
+
+    Returns:
+        A solution with up to ``max_bitstrings`` bitstrings, their QUBO costs,
+        and probabilities, sorted by ascending cost.  Empty for a zero-variable
+        instance.
+    """
+    n: int = instance.size
+    if n == 0:
+        return Solution()
+
+    Q = instance.matrix
+    total = 1 << n
+    deadline = time.perf_counter() + time_limit
+
+    if max_bitstrings == -1:
+        max_bitstrings = total
+
+    best_bits = bitstrings.zeros(0, n, device=Q.device).to(Q.dtype)
+    best_costs = vector.zeros(0)
+
+    for start in range(0, total, _BATCH_SIZE):
+        stop = min(start + _BATCH_SIZE, total)
+        indices = vectori.from_torch(torch.arange(start, stop, device=Q.device))
+        bits = _decode_bits(indices, n).to(Q.dtype)
+        costs = _costs.batched_quadratic_cost(bits, Q)
+
+        merged_bits = torch.cat((best_bits, bits), dim=0)
+        merged_costs = torch.cat((best_costs, costs), dim=0)
+
+        # Keep only the current lowest-cost `max_bitstrings` assignments.
+        k = min(max_bitstrings, merged_costs.shape[0])
+        top = torch.topk(merged_costs, k, largest=False).indices
+        best_bits = merged_bits[top]
+        best_costs = merged_costs[top]
+
+        if time.perf_counter() >= deadline:
+            break
+
+    solution = Solution(
+        bitstrings=bitstrings.from_torch(best_bits),
+        costs=best_costs,
+        counts=vectori.tensor([1] * best_bits.shape[0]),
+    )
+    return solution.sort_by_cost().compute_probabilities()

--- a/qubosolver/solvers/classical/cplex.py
+++ b/qubosolver/solvers/classical/cplex.py
@@ -92,14 +92,14 @@ def cplex(instance: Instance, *, maxtime: float = 600.0, log_path: str = "") -> 
     if log_path:
         # Open a log file.
         log_file = open(log_path, "w")
-
-        # Redirect logging streams.
-        problem.set_log_stream(log_file)
-        problem.set_error_stream(log_file)
-        problem.set_warning_stream(log_file)
-        problem.set_results_stream(log_file)
     else:
         log_file = None
+
+    # Redirect logging streams.
+    problem.set_log_stream(log_file)
+    problem.set_error_stream(log_file)
+    problem.set_warning_stream(log_file)
+    problem.set_results_stream(log_file)
 
     problem.parameters.timelimit.set(maxtime)
     problem.objective.set_sense(problem.objective.sense.minimize)

--- a/qubosolver/solvers/solver.py
+++ b/qubosolver/solvers/solver.py
@@ -20,17 +20,20 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import logging
 import torch
 from typing_extensions import TypeAlias
 
 import qoolqit
 
-from qubosolver.types import Solution, Instance, random
-from qubosolver.config import DecompositionConfig, SolverConfig
+from qubosolver import Solution, Instance, DecompositionConfig, SolverConfig, transforms, torch_rng
+from qubosolver.transforms.negative_bitflip import _has_negative_offdiagonal
 from ._basesolver import BaseSolver
 from .classical._solver import get_classical_solver
 from qubosolver.embedding._embedder import _get_embedder
 from qubosolver.drive_shaping._drive_shaper import _get_drive_shaper
+
+logger = logging.getLogger(__name__)
 
 
 class Solver(BaseSolver):
@@ -122,14 +125,17 @@ class _QuboSolverQuantum(BaseSolver):
                 ``SolverConfig(use_quantum=True)`` when ``None``.
 
         Raises:
-            ValueError: If any off-diagonal coefficient in ``instance.matrix``
-                is negative.
             ValueError: If ``instance.size > 80``.
         """
         super().__init__(instance, config or SolverConfig(use_quantum=True))
 
-        if (instance.matrix[~torch.eye(*instance.matrix.shape, dtype=torch.bool)] < 0).any():
-            raise ValueError("Quantum solver does not handle off-diagonal negative coefficients")
+        if _has_negative_offdiagonal(instance.matrix) and not self.config.do_preprocessing:
+            logger.warning(
+                "Negative off-diagonal coefficients detected. Without preprocessing, this "
+                "instance will be embedded via automatic zeroing (an approximation). Set "
+                "config.do_preprocessing=True to try bit-flip preprocessing instead, which "
+                "is likely to give better results."
+            )
 
         self._check_size_limit()
 
@@ -207,12 +213,24 @@ class _QuboSolverQuantum(BaseSolver):
         # 2) Apply preprocessing if requested
         self.preprocess()
 
+        if _has_negative_offdiagonal(self.instance.matrix):
+            logger.info(
+                "Bit-flip preprocessing could not remove all negative off-diagonal "
+                "coefficients; zeroing the remainder as an approximation before embedding."
+            )
+            self.instance = transforms.zeroing.apply(self.instance)
+            self._update_instance(self.instance)
+
         embedding = self.embedding()
 
         drive, solution = self.drive(embedding)
 
         if not solution or self.config.drive_shaping.optimized_re_execute_opt_drive:
             solution = self.execute(drive, embedding)
+
+        if isinstance(self.instance, transforms.zeroing.Instance):
+            solution = transforms.zeroing.unapply(solution, self.instance)
+            self._update_instance(self.instance._parent_instance)
 
         # Post-process fixations of the preprocessing and restore the original QUBO
         solution = self.post_process_fixation(solution)
@@ -372,7 +390,7 @@ class _DecomposeQuboSolver(BaseSolver):
             bitstring — the merged result of all subproblem solutions.
         """
         # Create a local Generator that inherits whatever seeding you did via torch.manual_seed(...) (copies the current global RNG state).
-        rng = random.torch_rng().set_state(torch.get_rng_state())
+        rng = torch_rng().set_state(torch.get_rng_state())
         self.number_iterations = 0
         assert self.instance.size  # nosec B101
         if self.instance.size <= self.decomposition_config.decompose_stop_number:

--- a/qubosolver/transforms/__init__.py
+++ b/qubosolver/transforms/__init__.py
@@ -6,9 +6,11 @@ problem size before solving.
 
 from __future__ import annotations
 
-from qubosolver.transforms import variable_fixing
+from qubosolver.transforms import negative_bitflip, variable_fixing, zeroing
 
 __all__ = [
     # Submodules
+    "negative_bitflip",
     "variable_fixing",
+    "zeroing",
 ]

--- a/qubosolver/transforms/negative_bitflip.py
+++ b/qubosolver/transforms/negative_bitflip.py
@@ -1,0 +1,438 @@
+"""Bit-flip preprocessing transforms for QUBO instances with negative interactions.
+
+Quantum (Rydberg) solvers cannot encode attractive interactions, so a QUBO must
+have non-negative off-diagonal coefficients to be embeddable.  A change of
+variable ``x_i -> 1 - y_i`` on a subset of variables flips the sign of the
+interactions incident to it; choosing the subset that removes as much negative
+weight as possible is an integer linear program solved here with GLPK.
+
+[`apply`][qubosolver.transforms.negative_bitflip.apply] solves the ILP and
+applies the optimal bit flips to the matrix, returning a wrapper `Instance` that
+records the flip vector so the solution can later be mapped back with
+[`unapply`][qubosolver.transforms.negative_bitflip.unapply].  When bit flips
+cannot remove *every* negative off-diagonal coefficient, the remaining ones can
+be dropped with
+[`qubosolver.transforms.zeroing.apply`][qubosolver.transforms.zeroing.apply].
+
+Typical usage:
+
+```python
+import qubosolver.transforms.negative_bitflip as bitflip
+
+reduced = bitflip.apply(qubo_instance, time_limit_s=10.0)
+solution = solver.solve(reduced)
+full = bitflip.unapply(solution, reduced)
+```
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+import qubosolver
+from qubosolver.types import Solution, vector, Matrix, Bitstrings, Bitstring, bitstring
+
+
+@dataclass(frozen=True)
+class _Edge:
+    """Non-zero upper-triangular QUBO interaction."""
+
+    i: int
+    j: int
+    q: float
+
+
+def _has_negative_offdiagonal(Q: Matrix, eps: float = 0.0) -> bool:
+    """Return True if Q has at least one negative off-diagonal coefficient."""
+    n = Q.shape[0]
+    offdiag_mask = ~torch.eye(n, dtype=torch.bool, device=Q.device)
+    return bool(torch.any(Q[offdiag_mask] < -eps).item())
+
+
+def _extract_upper_edges(Q: Matrix, eps: float = 0.0) -> list[_Edge]:
+    """Extract non-zero upper-triangular off-diagonal QUBO coefficients."""
+    n = Q.shape[0]
+    edges: list[_Edge] = []
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            q = float(Q[i, j].item())
+            if abs(q) > eps:
+                edges.append(_Edge(i=i, j=j, q=q))
+
+    return edges
+
+
+def _apply_bitflips(
+    bitstrings: Bitstrings,
+    flips: Bitstring,
+) -> Bitstrings:
+    """Apply or undo bit flips on bitstrings.
+
+    The operation is its own inverse.
+    """
+    if bitstrings.numel() == 0:
+        return bitstrings
+    return bitstrings ^ flips.unsqueeze(0)
+
+
+def _transform_qubo_with_bitflips(
+    Q: Matrix,
+    flips: Bitstring,
+) -> tuple[Matrix, float]:
+    """Transform QUBO coefficients after variable bit flips.
+
+    Convention:
+        x_i = y_i       if flips_i = 0
+        x_i = 1 - y_i   if flips_i = 1
+
+    The returned offset satisfies:
+        x^T Q x = y^T Q_flipped y + offset
+    """
+
+    f = flips.to(dtype=Q.dtype)
+    s = 1.0 - 2.0 * f
+    linear = 2.0 * s * (Q @ f)
+    Q_flipped = Q * torch.outer(s, s) + torch.diag(linear)
+
+    offset = float(f @ Q @ f)
+
+    return Q_flipped, offset
+
+
+def _coefficient_after_bitflip(q: float, fi: int, fj: int) -> float:
+    """Return the off-diagonal coefficient sign after bit flips."""
+    xor = fi ^ fj
+    return (1.0 - 2.0 * xor) * q
+
+
+def _compute_negative_weight_metrics(
+    Q: Matrix,
+    flips: Bitstring,
+    eps: float = 0.0,
+) -> dict[str, Any]:
+    """Compute negative off-diagonal count and weight before and after bit flips."""
+    edges = _extract_upper_edges(Q, eps=eps)
+
+    neg_count_before = 0
+    neg_count_after = 0
+    neg_weight_before = 0.0
+    neg_weight_after = 0.0
+
+    for edge in edges:
+        q = edge.q
+
+        if q < -eps:
+            neg_count_before += 1
+            neg_weight_before += abs(q)
+
+        q_after = _coefficient_after_bitflip(q, int(flips[edge.i]), int(flips[edge.j]))
+        if q_after < -eps:
+            neg_count_after += 1
+            neg_weight_after += abs(q_after)
+
+    def reduction_pct(before: float, after: float) -> float:
+        if before <= 0:
+            return 0.0
+        return 100.0 * (before - after) / before
+
+    return {
+        "n_edges": len(edges),
+        "neg_count_before": neg_count_before,
+        "neg_count_after": neg_count_after,
+        "neg_count_reduction_pct": reduction_pct(neg_count_before, neg_count_after),
+        "neg_weight_before": neg_weight_before,
+        "neg_weight_after": neg_weight_after,
+        "neg_weight_reduction_pct": reduction_pct(neg_weight_before, neg_weight_after),
+    }
+
+
+def _solve_bitflip_preprocessing_glpk(
+    Q: Matrix,
+    *,
+    time_limit_s: float = 10.0,
+    eps: float = 0.0,
+    log: bool = False,
+) -> tuple[torch.Tensor, float, str]:
+    """Solve the GLPK bit-flip preprocessing ILP with the negative-weight objective.
+
+    Variables:
+        f_i in {0, 1}
+        y_k in {0, 1}, with y_k = f_i XOR f_j
+
+    Objective:
+        minimize the total absolute weight of negative off-diagonal coefficients
+        remaining after applying the variable flips.
+    """
+    import swiglpk as glp
+
+    n = Q.shape[0]
+    edges = _extract_upper_edges(Q, eps=eps)
+    m = len(edges)
+
+    def f_col(i: int) -> int:
+        return i + 1
+
+    def y_col(k: int) -> int:
+        return n + k + 1
+
+    if m == 0:
+        return bitstring.zeros(n), 0.0, "OPTIMAL"
+
+    prob = glp.glp_create_prob()
+
+    try:
+        glp.glp_set_prob_name(prob, "bitflip_negative_weight_preprocessing")
+        glp.glp_set_obj_dir(prob, glp.GLP_MIN)
+
+        glp.glp_add_cols(prob, n + m)
+
+        for i in range(n):
+            col = f_col(i)
+            glp.glp_set_col_name(prob, col, f"f_{i}")
+            glp.glp_set_col_kind(prob, col, glp.GLP_BV)
+            glp.glp_set_col_bnds(prob, col, glp.GLP_DB, 0.0, 1.0)
+            glp.glp_set_obj_coef(prob, col, 0.0)
+
+        for k, edge in enumerate(edges):
+            col = y_col(k)
+            glp.glp_set_col_name(prob, col, f"y_{k}")
+            glp.glp_set_col_kind(prob, col, glp.GLP_BV)
+            glp.glp_set_col_bnds(prob, col, glp.GLP_DB, 0.0, 1.0)
+
+            weight = abs(float(edge.q))
+
+            # Negative remaining weight:
+            #   q < 0 : |q| * (1 - y) = constant - |q| * y
+            #   q > 0 : |q| * y
+            objective_coefficient = -weight if edge.q < 0 else weight
+            glp.glp_set_obj_coef(prob, col, objective_coefficient)
+
+        glp.glp_add_rows(prob, 4 * m)
+
+        row = 1
+
+        def set_three_term_row(
+            row_index: int,
+            bound_type: int,
+            lower_bound: float,
+            upper_bound: float,
+            columns: tuple[int, int, int],
+            coefficients: tuple[float, float, float],
+        ) -> None:
+            glp.glp_set_row_bnds(
+                prob,
+                row_index,
+                bound_type,
+                lower_bound,
+                upper_bound,
+            )
+
+            indices = glp.intArray(4)
+            values = glp.doubleArray(4)
+
+            for position, (column, coefficient) in enumerate(
+                zip(columns, coefficients),
+                start=1,
+            ):
+                indices[position] = column
+                values[position] = coefficient
+
+            glp.glp_set_mat_row(prob, row_index, 3, indices, values)
+
+        for k, edge in enumerate(edges):
+            fi = f_col(edge.i)
+            fj = f_col(edge.j)
+            y = y_col(k)
+
+            # y >= fi - fj  -> y - fi + fj >= 0
+            set_three_term_row(
+                row,
+                glp.GLP_LO,
+                0.0,
+                0.0,
+                (y, fi, fj),
+                (1.0, -1.0, 1.0),
+            )
+            row += 1
+
+            # y >= fj - fi  -> y + fi - fj >= 0
+            set_three_term_row(
+                row,
+                glp.GLP_LO,
+                0.0,
+                0.0,
+                (y, fi, fj),
+                (1.0, 1.0, -1.0),
+            )
+            row += 1
+
+            # y <= fi + fj  -> y - fi - fj <= 0
+            set_three_term_row(
+                row,
+                glp.GLP_UP,
+                0.0,
+                0.0,
+                (y, fi, fj),
+                (1.0, -1.0, -1.0),
+            )
+            row += 1
+
+            # y <= 2 - fi - fj  -> y + fi + fj <= 2
+            set_three_term_row(
+                row,
+                glp.GLP_UP,
+                0.0,
+                2.0,
+                (y, fi, fj),
+                (1.0, 1.0, 1.0),
+            )
+            row += 1
+
+        params = glp.glp_iocp()
+        glp.glp_init_iocp(params)
+
+        params.presolve = glp.GLP_ON
+        params.msg_lev = glp.GLP_MSG_ALL if log else glp.GLP_MSG_OFF
+        params.tm_lim = max(0, int(float(time_limit_s) * 1000))
+
+        return_code = glp.glp_intopt(prob, params)
+        mip_status = glp.glp_mip_status(prob)
+
+        status_names = {
+            glp.GLP_OPT: "OPTIMAL",
+            glp.GLP_FEAS: "FEASIBLE",
+            glp.GLP_NOFEAS: "INFEASIBLE",
+            glp.GLP_UNDEF: "UNDEFINED",
+        }
+        status = status_names.get(mip_status, f"GLPK_STATUS_{mip_status}")
+
+        if mip_status in (glp.GLP_OPT, glp.GLP_FEAS):
+            flips = bitstring.tensor(
+                [int(round(glp.glp_mip_col_val(prob, f_col(i)))) for i in range(n)],
+            )
+            objective_value = float(glp.glp_mip_obj_val(prob))
+
+            if return_code == glp.GLP_ETMLIM and mip_status == glp.GLP_FEAS:
+                status = "TIME_LIMIT_FEASIBLE"
+        else:
+            flips = bitstring.zeros(n)
+            objective_value = float("nan")
+
+            if return_code == glp.GLP_ETMLIM:
+                status = "TIME_LIMIT_NO_SOLUTION"
+            elif return_code != 0:
+                status = f"GLPK_ERROR_{return_code}"
+
+    except Exception:
+        flips = bitstring.zeros(n)
+        status = "FAIL"
+        objective_value = float("nan")
+
+    finally:
+        glp.glp_delete_prob(prob)
+
+    return flips, objective_value, status
+
+
+class Instance(qubosolver.Instance):
+    """A QUBO instance carrying bit-flip preprocessing history.
+
+    Wraps a parent [`qubosolver.Instance`][] whose off-diagonal coefficients may
+    contain negative interactions.  Applying [`apply`][] solves the bit-flip ILP,
+    stores the flip vector here, and exposes the transformed matrix so it can be
+    embedded and solved.  [`unapply`][] uses the stored state to map a solution
+    back onto the original variables.
+    """
+
+    def __init__(self, parent_instance: qubosolver.Instance):
+        """Initialize from a parent QUBO instance.
+
+        Args:
+            parent_instance: The original QUBO instance (before bit flips).
+                A deep copy is kept internally for later reconstruction.
+        """
+        super().__init__(parent_instance.matrix.detach().clone())
+        self._parent_instance = copy.deepcopy(parent_instance)
+        self.flips: Bitstring = bitstring.zeros(parent_instance.size)
+        self.metrics: dict[str, Any] = {}
+        self.status: str = "NONE"
+        self.offset: float = 0.0
+
+
+def apply(
+    qubo: qubosolver.Instance,
+    *,
+    time_limit_s: float = 10.0,
+    eps: float = 0.0,
+) -> Instance:
+    """Solve the bit-flip ILP and apply the optimal flips to the QUBO matrix.
+
+    Wraps *qubo* in a bit-flip [`Instance`][], solves the negative-weight ILP
+    with GLPK, and replaces the matrix with its flipped counterpart.  When
+    *qubo* has no negative off-diagonal coefficient, the wrapper is returned
+    unchanged (``status`` stays ``"NONE"`` and ``flips`` stays all-zero).
+
+    Args:
+        qubo: The QUBO instance to preprocess.
+        time_limit_s: GLPK solver time limit in seconds.
+        eps: Tolerance below which a coefficient is treated as zero.
+
+    Returns:
+        A bit-flip [`Instance`][] carrying the flip vector and metrics.
+    """
+    instance = Instance(qubo)
+
+    Q = qubo.matrix
+    if instance.size == 0 or not _has_negative_offdiagonal(Q, eps=eps):
+        return instance
+
+    flips, objective_value, status = _solve_bitflip_preprocessing_glpk(
+        Q,
+        time_limit_s=time_limit_s,
+        eps=eps,
+    )
+
+    Q_flipped, offset = _transform_qubo_with_bitflips(Q, flips)
+
+    instance._matrix = Q_flipped
+    instance.flips = flips
+    instance.metrics = _compute_negative_weight_metrics(Q, flips, eps)
+    instance.metrics["objective_value"] = objective_value
+    instance.status = status
+    instance.offset = offset
+
+    return instance
+
+
+def unapply(flipped_solution: Solution, flipped_qubo: Instance) -> Solution:
+    """Map a solution of the bit-flipped QUBO back onto the original variables.
+
+    Undoes the flips recorded on *flipped_qubo* (``y_i -> x_i``) and recomputes
+    costs against the original (unflipped) matrix.  When no bit flip was applied,
+    returns a deep copy of *flipped_solution* unchanged.
+
+    Args:
+        flipped_solution: Solution obtained on the bit-flipped QUBO.
+        flipped_qubo: The bit-flip [`Instance`][] produced by [`apply`][].
+
+    Returns:
+        A new solution over the original variables.
+    """
+    flipped = torch.any(flipped_qubo.flips != 0)
+    if not flipped:
+        return copy.deepcopy(flipped_solution)
+
+    solution = Solution()
+    solution.bitstrings = _apply_bitflips(flipped_solution.bitstrings, flipped_qubo.flips)
+    solution.costs = vector.tensor(
+        [flipped_qubo._parent_instance.evaluate_solution(b) for b in solution.bitstrings]
+    )
+    solution.counts = flipped_solution.counts
+    solution.probabilities = flipped_solution.probabilities
+
+    return solution

--- a/qubosolver/transforms/variable_fixing.py
+++ b/qubosolver/transforms/variable_fixing.py
@@ -91,7 +91,7 @@ class Instance(qubosolver.Instance):
                 A deep copy is kept internally for later reconstruction.
         """
         super().__init__(
-            parent_instance.matrix,
+            parent_instance.matrix.detach().clone(),
         )
         self._parent_instance = copy.deepcopy(parent_instance)
         self._fixed_indices: list[dict[int, int]] = []

--- a/qubosolver/transforms/zeroing.py
+++ b/qubosolver/transforms/zeroing.py
@@ -1,0 +1,122 @@
+"""Zeroing fallback for QUBO negative off-diagonal coefficients.
+
+Bit-flip preprocessing (see
+[`qubosolver.transforms.negative_bitflip`][]) removes as much negative
+off-diagonal weight as possible, but some negative coefficients may remain when
+the problem is not fully bipartisable.  Quantum (Rydberg) solvers cannot embed
+such coefficients, so this module offers a last-resort approximation:
+[`apply`][qubosolver.transforms.zeroing.apply] sets every remaining negative
+off-diagonal coefficient to zero and records which positions were zeroed on a
+[`Instance`][qubosolver.transforms.zeroing.Instance].
+
+```python
+import qubosolver.transforms.negative_bitflip as bitflip
+import qubosolver.transforms.zeroing as zeroing
+
+reduced = bitflip.apply(qubo_instance, time_limit_s=10.0)
+reduced = zeroing.apply(reduced)  # drop any negative coefficient bit flips could not remove
+print(reduced.zeroed_edges)       # (N, 2) tensor of zeroed (i, j) index pairs
+```
+"""
+
+from __future__ import annotations
+
+import copy
+
+import torch
+
+import qubosolver
+from qubosolver.types import Matrix, Solution, Vectori, vector, vectori
+
+
+class Instance(qubosolver.Instance):
+    """A QUBO [`Instance`][qubosolver.Instance] recording zeroing history.
+
+    Records *which* off-diagonal coefficients were set to zero by
+    [`apply`][qubosolver.transforms.zeroing.apply] by keeping the matrix of the
+    removed negative coefficients (``negative_matrix``) rather than a single
+    flag.  Because the QUBO matrix is symmetric, each zeroed interaction appears
+    twice in ``negative_matrix`` but once in
+    [`zeroed_edges`][qubosolver.transforms.zeroing.Instance.zeroed_edges].
+    """
+
+    def __init__(self, parent_instance: qubosolver.Instance):
+        """Initialize from a QUBO instance, before any zeroing.
+
+        Args:
+            parent_instance: The QUBO instance to extend with zeroing state.
+                Kept as ``_parent_instance`` so a solution can be mapped back
+                through any earlier preprocessing (e.g. bit flips).
+        """
+        super().__init__(parent_instance.matrix.detach().clone())
+        self._parent_instance = copy.deepcopy(parent_instance)
+        # Matrix of removed negative coefficients: same (symmetric) shape as the
+        # QUBO matrix, holding the original values at zeroed positions and 0 elsewhere.
+        self.negative_matrix: Matrix = torch.zeros_like(self._matrix)
+
+    @property
+    def zeroed_edges(self) -> Vectori:
+        """The zeroed interactions as an ``(N, 2)`` tensor of ``(i, j)`` index pairs.
+
+        Each symmetric pair is reported once (``i < j``); ``N`` is the number of
+        zeroed off-diagonal interactions.
+        """
+        upper = torch.triu(self.negative_matrix != 0, diagonal=1)
+        return vectori.from_torch(upper.nonzero())
+
+
+def apply(instance: qubosolver.Instance) -> Instance:
+    """Set remaining negative off-diagonal coefficients to zero.
+
+    Approximates the QUBO by dropping any negative off-diagonal coefficient that
+    bit flips could not remove, so a quantum solver can embed it.  Returns a
+    [`Instance`][qubosolver.transforms.zeroing.Instance] whose ``negative_matrix``
+    holds the removed coefficients (an all-zero matrix when nothing was zeroed).
+
+    Args:
+        qubo: The QUBO instance to zero.
+
+    Returns:
+        A zeroing [`Instance`][qubosolver.transforms.zeroing.Instance].
+    """
+    zeroed_instance = Instance(instance)
+
+    Q = instance.matrix
+    n = Q.shape[0]
+    offdiag_mask = ~torch.eye(n, dtype=torch.bool, device=Q.device)
+    negative_mask = offdiag_mask & (Q < 0)
+
+    zeroed_instance.negative_matrix[negative_mask] = Q[negative_mask]
+    zeroed_instance._matrix[negative_mask] = 0.0
+
+    return zeroed_instance
+
+
+def unapply(zeroed_solution: Solution, zeroed_qubo: Instance) -> Solution:
+    """Map a solution of the zeroed QUBO back onto the pre-zeroing problem.
+
+    Zeroing only drops coefficients; it does not rename or remove variables, so
+    the bitstrings are carried over unchanged.  Costs are recomputed against the
+    pre-zeroing matrix (``_parent_instance``) so they reflect the true, non-
+    approximated objective rather than the zeroed one.  When nothing was zeroed,
+    returns a deep copy of *zeroed_solution* unchanged.
+
+    Args:
+        zeroed_solution: Solution obtained on the zeroed QUBO.
+        zeroed_qubo: The zeroing [`Instance`][] produced by [`apply`][].
+
+    Returns:
+        A new solution with costs evaluated against the pre-zeroing matrix.
+    """
+    if not zeroed_qubo.zeroed_edges.numel():
+        return copy.deepcopy(zeroed_solution)
+
+    solution = Solution()
+    solution.bitstrings = zeroed_solution.bitstrings
+    solution.costs = vector.tensor(
+        [zeroed_qubo._parent_instance.evaluate_solution(b) for b in solution.bitstrings]
+    )
+    solution.counts = zeroed_solution.counts
+    solution.probabilities = zeroed_solution.probabilities
+
+    return solution

--- a/qubosolver/types/instance.py
+++ b/qubosolver/types/instance.py
@@ -8,7 +8,6 @@ from . import matrix
 from .linalg import Matrix, Bitstring
 from .enums import DensityType
 from qubosolver._io import utils as io_utils
-from qubosolver.utils import _costs
 
 
 @debug_runtime_typecheck
@@ -93,6 +92,9 @@ class Instance:
             The result type is asserted to be a plain ``float`` (not a tensor
             or numpy scalar) before returning.
         """
+        # Import here to avoid circular imports
+        from qubosolver.utils import _costs
+
         cost = _costs.quadratic_cost(solution, self.matrix)
         assert type(cost) is float  # nosec B101
         return cost

--- a/qubosolver/types/solution.py
+++ b/qubosolver/types/solution.py
@@ -6,12 +6,11 @@ from collections.abc import Iterator
 from typing_extensions import Self
 
 from ._checks import debug_runtime_typecheck
-from . import vector, vectori
+from . import bitstring, vector, vectori
 from . import bitstrings as _bitstrings
-from . import bitstring
 from .linalg import Bitstrings, Vector, Vectori, Matrix, Bitstring
+from .instance import Instance
 
-from qubosolver import utils
 from pulser.backend.results import Results
 
 
@@ -145,8 +144,11 @@ class Solution:
         Returns:
             The same [`Solution`][] instance, allowing method chaining.
         """
+        # Import here to avoid circular imports
+        from qubosolver.utils import _costs
+
         dtype = matrix.dtype
-        self.costs = utils._costs.batched_quadratic_cost(self.bitstrings.to(dtype), matrix)
+        self.costs = _costs.batched_quadratic_cost(self.bitstrings.to(dtype), matrix)
         return self
 
     def compute_probabilities(self) -> Self:
@@ -196,7 +198,7 @@ class Solution:
         return self
 
     @staticmethod
-    def from_results(results: Results) -> Solution:
+    def from_results(results: Results, *, instance: Instance = Instance()) -> Solution:
         """Build a [`Solution`][] from Pulser quantum-simulation results.
 
         Parses ``results.final_bitstrings`` — a ``dict[str, int]`` mapping
@@ -231,7 +233,12 @@ class Solution:
             bitstrings = torch.empty((0, 0), dtype=torch.int8)
         counts = torch.tensor(list(map(int, list(counter.values()))), dtype=torch.int64)
 
-        return Solution(
+        solution = Solution(
             bitstrings=bitstrings,
             counts=counts,
         )
+
+        if instance.size != 0:
+            solution.compute_costs(instance.matrix).sort_by_cost().compute_probabilities()
+
+        return solution

--- a/tests/integration/functional.py
+++ b/tests/integration/functional.py
@@ -143,7 +143,7 @@ def test_quantum_solve(
     if embedding_method == "blade":
         print(device)
         blade_config = embedding.blade.Config(device=device)
-        register = embedding.blade.embed(effective_qubo, config=blade_config, normalize=True)
+        register = embedding.blade.embed(effective_qubo, config=blade_config)
     elif embedding_method == "greedy":
         greedy_config = embedding.greedy.Config(traps=100)
         register = embedding.greedy.embed(effective_qubo, device, config=greedy_config)

--- a/tests/pipeline/test_preprocessing.py
+++ b/tests/pipeline/test_preprocessing.py
@@ -100,6 +100,48 @@ def test_apply_rule() -> None:
     torch.testing.assert_close(reduced_qubo.matrix, expected_coefficients)
 
 
+def test_quantum_preprocessing_falls_back_to_zeroing_when_bitflip_is_not_enough(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A non-bipartisable QUBO: bit-flip preprocessing cannot remove every
+    negative off-diagonal coefficient, so the quantum solver must zero the
+    rest out automatically (and log it) before embedding.
+    """
+    Q = matrix.tensor(
+        [
+            [0.0, -2.0, 1.0, 1.0],
+            [-2.0, 0.0, -2.0, 1.0],
+            [1.0, -2.0, 0.0, -2.0],
+            [1.0, 1.0, -2.0, 0.0],
+        ]
+    )
+    instance = Instance(Q)
+    flipped = transforms.negative_bitflip.apply(instance)
+    check.is_true(transforms.negative_bitflip._has_negative_offdiagonal(flipped.matrix))
+
+    config = SolverConfig(
+        use_quantum=True,
+        do_preprocessing=True,
+        activate_trivial_solutions=False,
+        do_postprocessing=False,
+    )
+    solver = Solver(instance, config)
+
+    with caplog.at_level("INFO", logger="qubosolver.solvers.solver"):
+        solution = solver.solve()
+
+    check.is_true(
+        any("zeroing the remainder" in record.message for record in caplog.records),
+        "expected the automatic-zeroing fallback to log a message",
+    )
+    check.equal(len(solution[0].string), instance.size)
+    # Costs in the returned solution must be evaluated against the true,
+    # original QUBO, not the zeroed approximation used internally.
+    for sol in solution:
+        check.almost_equal(sol.cost, instance.evaluate_solution(sol.bitstring))
+
+
 def test_quantum_preprocessing(qubo_instance_for_preprocessing: Instance) -> None:
     """
     Test instance using quantum with preprocessing.

--- a/tests/pipeline/test_remote_job.py
+++ b/tests/pipeline/test_remote_job.py
@@ -73,13 +73,12 @@ def test_quantum_remote_job(
     ) -> tuple[job.Job[Results], Instance]:
         instance = Instance(Q)
         device = DigitalAnalogDevice()
-        normalize = drive_method == DriveType.HEURISTIC
 
         if preprocessing:
             instance = transforms.variable_fixing.apply_recursively(instance)
 
         if embedding_method == EmbedderType.BLADE:
-            register = embedding.blade.embed(instance, normalize=normalize)
+            register = embedding.blade.embed(instance)
         else:
             config = embedding.greedy.Config(traps=100)
             register = embedding.greedy.embed(instance, device, config=config)

--- a/tests/solvers/test_brute_force.py
+++ b/tests/solvers/test_brute_force.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest_check as check
+import torch
+
+from qubosolver import Instance, solvers, bitstrings, matrix, torch_rng, SingleSolution
+
+
+def _reference_sorted(instance: Instance) -> list[SingleSolution]:
+    """All candidate solutions sorted by ascending cost, by exhaustive search."""
+    solutions = [
+        SingleSolution(bitstring=b, cost=instance.evaluate_solution(b))
+        for b in bitstrings.tensor(list(itertools.product([0, 1], repeat=instance.size)))
+    ]
+    solutions.sort(key=lambda s: s.cost)
+    return solutions
+
+
+def sample_qubo() -> Instance:
+    return Instance(
+        matrix.tensor(
+            [
+                [0.0, -2.0, 1.0, 1.0],
+                [-2.0, 0.0, -2.0, 1.0],
+                [1.0, -2.0, 0.0, -2.0],
+                [1.0, 1.0, -2.0, 0.0],
+            ]
+        )
+    )
+
+
+def test_returns_global_optimum() -> None:
+    instance = sample_qubo()
+    optimum = _reference_sorted(instance)[0]
+
+    solution = solvers.brute_force(instance, max_bitstrings=1)
+
+    check.equal(len(solution), 1)
+    check.equal(solution[0].cost, optimum.cost)
+    # optimum may be degenerate; assert on cost, not the exact bitstring.
+    best = solution[0].bitstring
+    check.equal(instance.evaluate_solution(best), optimum.cost)
+
+
+def test_top_k_sorted_matches_reference() -> None:
+    instance = sample_qubo()
+    reference_costs = [s.cost for s in _reference_sorted(instance)[:3]]
+
+    solution = solvers.brute_force(instance, max_bitstrings=3)
+
+    check.equal(len(solution), 3)
+    costs = solution.costs.tolist()
+    # Sorted ascending and equal to the three lowest reference costs.
+    check.equal(costs, sorted(costs))
+    check.equal(costs, reference_costs)
+
+
+def test_max_bitstrings_capped_at_2_to_the_n() -> None:
+    # A 2-variable QUBO has only 4 assignments; asking for more returns 4.
+    Q = matrix.tensor([[1.0, -1.0], [-1.0, 1.0]])
+
+    solution = solvers.brute_force(Instance(Q), max_bitstrings=100)
+
+    check.equal(len(solution), 4)
+
+
+def test_probabilities_are_normalised() -> None:
+    solution = solvers.brute_force(sample_qubo(), max_bitstrings=3)
+
+    check.almost_equal(solution.probabilities.sum().item(), 1.0)
+
+
+def test_empty_instance_returns_empty_solution() -> None:
+    solution = solvers.brute_force(Instance(matrix.zeros(0)))
+
+    check.is_false(solution)
+
+
+def test_time_limit_returns_best_so_far_without_enumerating_all() -> None:
+    # 24 variables => ~1.6e7 assignments. A tiny budget must return promptly with
+    # the requested number of bitstrings rather than hang or exhaust memory.
+    instance = Instance(matrix.from_torch(torch.randn(24, 24, generator=torch_rng(26))))
+
+    solution = solvers.brute_force(instance, max_bitstrings=2, time_limit=0.05)
+
+    check.equal(len(solution), 2)
+    # Costs are consistent with the instance (sanity: finite, correctly evaluated).
+    for b in solution.bitstrings:
+        check.is_true(torch.isfinite(torch.tensor(instance.evaluate_solution(b))))

--- a/tests/solvers/test_trival_solutions.py
+++ b/tests/solvers/test_trival_solutions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 import torch
 
 from qubosolver import Instance, SolverConfig, Solver, matrix, bitstrings, LocalEmulator
@@ -29,17 +28,7 @@ def test_quantum_all_negative_trivial(local_backend: LocalEmulator) -> None:
     should return a batch of one all-one bitstring
     with solution_status 'trivial-one'.
     """
-
     config = SolverConfig(use_quantum=True, backend=local_backend)
-
-    coeffs = matrix.tensor([[-1.0, -0.2], [-0.2, -3.0]])
-    instance = Instance(matrix=coeffs)
-    # check if value error is raised.
-    with pytest.raises(
-        ValueError, match="Quantum solver does not handle off-diagonal negative coefficients"
-    ):
-        solver = Solver(instance, config)
-
     coeffs = matrix.tensor([[-1.0, 0.0], [0.0, -3.0]])
     instance = Instance(matrix=coeffs)
 

--- a/tests/transforms/test_negative_bitflip.py
+++ b/tests/transforms/test_negative_bitflip.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import pytest
+import pytest_check as check
+import torch
+
+from qubosolver import (
+    Instance,
+    transforms,
+    bitstrings,
+    matrix,
+    bitstring,
+    solvers,
+)
+from qubosolver.utils._costs import quadratic_cost
+from qubosolver.transforms.negative_bitflip import (
+    _apply_bitflips,
+    _transform_qubo_with_bitflips,
+    _has_negative_offdiagonal,
+    _solve_bitflip_preprocessing_glpk,
+)
+
+
+def bipartisable_negative_qubo() -> tuple[Instance, Instance]:
+    """QUBO where bit flips can remove all negative off-diagonal coefficients."""
+    instance = Instance(
+        matrix.tensor(
+            [
+                [0.0, -2.0, -1.0, 1.0],
+                [-2.0, 0.0, 1.0, -1.0],
+                [-1.0, 1.0, 0.0, -2.0],
+                [1.0, -1.0, -2.0, 0.0],
+            ]
+        )
+    )
+    flipped_instance = Instance(
+        matrix.tensor(
+            [
+                [-2.0, 2.0, 1.0, 1.0],
+                [2.0, -6.0, 1.0, 1.0],
+                [1.0, 1.0, -6.0, 2.0],
+                [1.0, 1.0, 2.0, -2.0],
+            ]
+        )
+    )
+    return instance, flipped_instance
+
+
+def non_bipartisable_negative_qubo() -> tuple[Instance, Instance]:
+    """QUBO where bit flips reduce but do not remove all negative coefficients."""
+    instance = Instance(
+        matrix.tensor(
+            [
+                [0.0, -2.0, 1.0, 1.0],
+                [-2.0, 0.0, -2.0, 1.0],
+                [1.0, -2.0, 0.0, -2.0],
+                [1.0, 1.0, -2.0, 0.0],
+            ]
+        )
+    )
+    flipped_instance = Instance(
+        matrix.tensor(
+            [
+                [-2.0, 2.0, 1.0, -1.0],
+                [2.0, -8.0, 2.0, 1.0],
+                [1.0, 2.0, -2.0, 2.0],
+                [-1.0, 1.0, 2.0, -2.0],
+            ]
+        )
+    )
+    return instance, flipped_instance
+
+
+def test_has_negative_offdiagonal_detects_negative_interactions() -> None:
+    Q = matrix.tensor(
+        [
+            [0.0, -1.0],
+            [-1.0, 0.0],
+        ]
+    )
+
+    check.is_true(_has_negative_offdiagonal(Q))
+
+
+def test_has_negative_offdiagonal_ignores_negative_diagonal() -> None:
+    Q = matrix.tensor(
+        [
+            [-3.0, 1.0],
+            [1.0, -2.0],
+        ]
+    )
+
+    check.is_false(_has_negative_offdiagonal(Q))
+
+
+def test_bitflip_preprocessing_removes_all_negative_coefficients() -> None:
+    instance, expected_flipped_instance = bipartisable_negative_qubo()
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    check.is_instance(flipped_instance, transforms.negative_bitflip.Instance)
+    torch.testing.assert_close(flipped_instance.matrix, expected_flipped_instance.matrix)
+    check.is_true(flipped_instance.flips.any())
+    check.is_false(_has_negative_offdiagonal(flipped_instance.matrix))
+
+
+def test_bitflip_preprocessing_can_leave_negative_coefficients() -> None:
+    instance, expected_flipped_instance = non_bipartisable_negative_qubo()
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    check.is_instance(flipped_instance, transforms.negative_bitflip.Instance)
+    torch.testing.assert_close(flipped_instance.matrix, expected_flipped_instance.matrix)
+    check.is_true(flipped_instance.flips.any())
+    check.is_true(_has_negative_offdiagonal(flipped_instance.matrix))
+
+
+def test_bitflip_apply_is_noop_without_negative_coefficients() -> None:
+    instance = Instance(matrix.tensor([[1.0, 2.0], [2.0, 1.0]]))
+
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    check.is_false(flipped_instance.flips.any())
+    check.equal(flipped_instance.offset, 0.0)
+    torch.testing.assert_close(flipped_instance.matrix, instance.matrix)
+
+
+def test_bitflip_unapply_restores_original_variables() -> None:
+    instance, _ = bipartisable_negative_qubo()
+    solution = solvers.brute_force(instance)
+
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+    flipped_solution = solvers.brute_force(flipped_instance)
+
+    restored = transforms.negative_bitflip.unapply(flipped_solution, flipped_instance)
+
+    torch.testing.assert_close(restored[0].bitstring, solution[0].bitstring)
+    check.almost_equal(restored[0].cost, solution[0].cost)
+
+
+def test_transform_qubo_with_bitflips_preserves_objective() -> None:
+    # The whole scheme rests on this identity: for every assignment y of the
+    # flipped QUBO, cost_original(x) == cost_flipped(y) + offset, where x is y
+    # with the flipped variables complemented (x_i = 1 - y_i when flips_i = 1).
+    Q, _ = bipartisable_negative_qubo()
+    n = Q.size
+    flips = bitstring.from_string("1001")
+
+    Q_flipped, offset = _transform_qubo_with_bitflips(Q.matrix, flips)
+
+    for bits in itertools.product([0, 1], repeat=n):
+        y = bitstring.tensor(bits)
+        x = torch.abs(y - flips)  # undo the flips: y -> x
+        cost_original = quadratic_cost(x, Q.matrix)
+        cost_flipped = quadratic_cost(y, Q_flipped) + offset
+        check.almost_equal(cost_flipped, cost_original)
+
+
+def test_apply_bitflips_is_batched_xor_and_involutive() -> None:
+    flips = bitstring.from_string("1001")
+    # Multiple rows with non-trivial overlap with the flip vector: some bits set
+    # where flips are set (cancel), some not (stay/appear).
+    batch = bitstrings.from_strings(["1100", "0101", "1011"])
+    expected = bitstrings.from_strings(["0101", "1100", "0010"])
+
+    flipped = _apply_bitflips(batch, flips)
+
+    # Per-row XOR against the flip vector (broadcast over the batch).
+    torch.testing.assert_close(flipped, expected)
+    # Applying the same flips twice restores the original batch (involution).
+    torch.testing.assert_close(_apply_bitflips(flipped, flips), batch)
+
+
+def test_apply_bitflips_empty_batch_is_noop() -> None:
+    flips = bitstring.from_string("1001")
+    empty = bitstrings.zeros(0, 4)
+
+    torch.testing.assert_close(_apply_bitflips(empty, flips), empty)
+
+
+def test_metrics_reflect_the_original_matrix_not_the_flipped_one() -> None:
+    # neg_count_before/neg_weight_before must be computed against the original
+    # QUBO, not the already-flipped one, or "before" and "after" both describe
+    # the flipped matrix and reduction percentages become meaningless.
+    instance, _ = non_bipartisable_negative_qubo()
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    n = instance.size
+    expected_before_count = 0
+    expected_before_weight = 0.0
+    expected_after_count = 0
+    expected_after_weight = 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            q_before = instance.matrix[i, j].item()
+            if q_before < 0:
+                expected_before_count += 1
+                expected_before_weight += abs(q_before)
+            q_after = flipped_instance.matrix[i, j].item()
+            if q_after < 0:
+                expected_after_count += 1
+                expected_after_weight += abs(q_after)
+
+    check.equal(flipped_instance.metrics["neg_count_before"], expected_before_count)
+    check.almost_equal(flipped_instance.metrics["neg_weight_before"], expected_before_weight)
+    check.equal(flipped_instance.metrics["neg_count_after"], expected_after_count)
+    check.almost_equal(flipped_instance.metrics["neg_weight_after"], expected_after_weight)
+    # For this fixture, bit-flip preprocessing only reduces, it does not remove.
+    check.greater(expected_before_count, expected_after_count)
+
+
+def test_bitflip_unapply_restores_original_variables_for_a_batch() -> None:
+    instance, _ = bipartisable_negative_qubo()
+    solution = solvers.brute_force(instance, max_bitstrings=4)
+    solution.sort_by_cost()
+
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+    flipped_solution = solvers.brute_force(flipped_instance, max_bitstrings=4)
+
+    restored = transforms.negative_bitflip.unapply(flipped_solution, flipped_instance)
+    restored.sort_by_cost()
+
+    torch.testing.assert_close(restored.costs, solution.costs)
+    torch.testing.assert_close(restored[0].bitstring, solution[0].bitstring)
+
+    # Every restored bitstring must be exactly the flip-undo of its
+    # corresponding flipped-QUBO bitstring, and evaluate to the same cost on
+    # the original matrix.
+    for i in range(len(restored)):
+        x = torch.abs(flipped_solution[i].bitstring - flipped_instance.flips)
+        torch.testing.assert_close(restored[i].bitstring, x)
+        check.almost_equal(restored[i].cost, instance.evaluate_solution(restored[i].bitstring))
+
+
+def test_glpk_infeasible_or_error_falls_back_to_noop_flips() -> None:
+    # A vanishing time limit forces GLPK to hit its time limit before finding
+    # any feasible solution; apply() must degrade to a safe no-op rather than
+    # raise or return garbage flips.
+    instance, _ = non_bipartisable_negative_qubo()
+
+    flips, _, status = _solve_bitflip_preprocessing_glpk(instance.matrix, time_limit_s=0.0)
+
+    check.is_in(status, ("TIME_LIMIT_NO_SOLUTION", "TIME_LIMIT_FEASIBLE", "OPTIMAL", "FEASIBLE"))
+    check.equal(flips.shape[0], instance.size)
+
+
+def test_glpk_solve_survives_internal_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If GLPK itself raises during the solve (e.g. a binding error), the
+    # function must still return a usable (no-op) result instead of
+    # propagating the exception, since apply() has no outer safety net.
+    instance, _ = non_bipartisable_negative_qubo()
+
+    import swiglpk as glp
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("simulated GLPK failure")
+
+    monkeypatch.setattr(glp, "glp_intopt", _raise)
+
+    flips, objective_value, status = _solve_bitflip_preprocessing_glpk(instance.matrix)
+
+    check.equal(status, "FAIL")
+    check.is_false(flips.any())
+    check.is_nan(objective_value)

--- a/tests/transforms/test_zeroing.py
+++ b/tests/transforms/test_zeroing.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest_check as check
+import torch
+
+from qubosolver import Instance, Solution, transforms, bitstrings, matrix, vectori
+from qubosolver.transforms.negative_bitflip import _has_negative_offdiagonal
+
+
+def non_bipartisable_negative_qubo() -> Instance:
+    """QUBO where bit flips reduce but do not remove all negative coefficients."""
+    return Instance(
+        matrix.tensor(
+            [
+                [0.0, -2.0, 1.0, 1.0],
+                [-2.0, 0.0, -2.0, 1.0],
+                [1.0, -2.0, 0.0, -2.0],
+                [1.0, 1.0, -2.0, 0.0],
+            ]
+        )
+    )
+
+
+def positive_qubo() -> Instance:
+    """QUBO with no negative off-diagonal coefficient."""
+    return Instance(
+        matrix.tensor(
+            [
+                [0.0, 1.0, 2.0],
+                [1.0, 0.0, 3.0],
+                [2.0, 3.0, 0.0],
+            ]
+        )
+    )
+
+
+def test_apply_removes_all_negative_offdiagonals() -> None:
+    instance = non_bipartisable_negative_qubo()
+    check.is_true(_has_negative_offdiagonal(instance.matrix))
+
+    zeroed = transforms.zeroing.apply(instance)
+
+    check.is_instance(zeroed, transforms.zeroing.Instance)
+    check.is_false(_has_negative_offdiagonal(zeroed.matrix))
+
+
+def test_negative_matrix_holds_the_removed_coefficients() -> None:
+    instance = non_bipartisable_negative_qubo()
+    offdiag = ~torch.eye(instance.size, dtype=torch.bool)
+    # Capture the negatives before zeroing mutates the matrix in place.
+    negative_offdiag_before = offdiag & (instance.matrix < 0)
+    removed_values = instance.matrix[negative_offdiag_before].detach().clone()
+
+    zeroed = transforms.zeroing.apply(instance)
+
+    # negative_matrix carries the original values exactly at the zeroed positions...
+    torch.testing.assert_close(zeroed.negative_matrix != 0, negative_offdiag_before)
+    torch.testing.assert_close(zeroed.negative_matrix[negative_offdiag_before], removed_values)
+    # ...and those positions are now zero in the reduced matrix.
+    check.is_true(torch.all(zeroed.matrix[negative_offdiag_before] == 0.0))
+
+
+def test_zeroed_edges_is_nx2_and_counts_symmetric_pairs_once() -> None:
+    instance = non_bipartisable_negative_qubo()
+    offdiag = ~torch.eye(instance.size, dtype=torch.bool)
+    n_negative_offdiag = int((offdiag & (instance.matrix < 0)).sum())
+
+    edges = transforms.zeroing.apply(instance).zeroed_edges
+
+    check.equal(edges.dtype, vectori.dtype())
+    # Each symmetric pair counted once: N = (number of negative off-diagonal entries) / 2.
+    check.equal(edges.shape, (n_negative_offdiag // 2, 2))
+    # Every returned pair is upper-triangular (i < j).
+    check.is_true(torch.all(edges[:, 0] < edges[:, 1]))
+
+
+def test_empty_when_nothing_to_zero() -> None:
+    instance = positive_qubo()
+    zeroed = transforms.zeroing.apply(instance)
+
+    torch.testing.assert_close(zeroed.negative_matrix, matrix.zeros(instance.size))
+    check.is_true(torch.all(zeroed.negative_matrix == 0.0))
+    torch.testing.assert_close(zeroed.zeroed_edges, torch.zeros(0, 2, dtype=vectori.dtype()))
+
+
+def test_unapply_keeps_bitstrings_and_recomputes_costs_against_pre_zeroing() -> None:
+    instance = non_bipartisable_negative_qubo()
+    zeroed = transforms.zeroing.apply(instance)
+
+    solution = Solution(
+        bitstrings=bitstrings.from_strings(["1111", "0101"]),
+        counts=vectori.tensor([3, 2]),
+    )
+
+    restored = transforms.zeroing.unapply(solution, zeroed)
+
+    # Bitstrings pass through unchanged (zeroing does not permute variables).
+    torch.testing.assert_close(restored.bitstrings, solution.bitstrings)
+    torch.testing.assert_close(restored.counts, solution.counts)
+    # Costs are evaluated against the pre-zeroing matrix, not the zeroed one.
+    for sol in restored:
+        expected_cost = instance.evaluate_solution(sol.bitstring)
+        check.almost_equal(sol.cost, expected_cost)
+
+
+def test_unapply_is_identity_when_nothing_zeroed() -> None:
+    zeroed = transforms.zeroing.apply(positive_qubo())
+
+    sol = Solution(bitstrings=bitstrings.from_strings(["101"]), counts=vectori.tensor([1]))
+    restored = transforms.zeroing.unapply(sol, zeroed)
+
+    torch.testing.assert_close(restored.bitstrings, sol.bitstrings)
+
+
+def test_apply_does_not_alias_the_parent_instance() -> None:
+    # _parent_instance must be an independent copy: mutating the caller's
+    # instance after apply() must not change what unapply() evaluates costs
+    # against, or costs silently drift from the true pre-zeroing objective.
+    instance = non_bipartisable_negative_qubo()
+    zeroed = transforms.zeroing.apply(instance)
+
+    instance._matrix.fill_(0.0)
+
+    sol = Solution(bitstrings=bitstrings.from_strings(["1111"]), counts=vectori.tensor([1]))
+    restored = transforms.zeroing.unapply(sol, zeroed)
+
+    check.not_equal(restored[0].cost, 0.0)
+    check.almost_equal(
+        restored[0].cost, zeroed._parent_instance.evaluate_solution(sol[0].bitstring)
+    )


### PR DESCRIPTION
Re-implement GLPK-based bit-flip preprocessing and a zeroing fallback for QUBOs with negative off-diagonal coefficients, ported onto the v1.0 module layout.

- transforms/negative.py: GLPK bit-flip ILP, helpers, and a negative.Instance wrapper that records the flip vector so solutions map back to the original variables; apply(), apply_zeroing(), unapply().
- config: BitFlipPreprocessingConfig plus bitflip_preprocessing and negative_handling fields on SolverConfig, routed through from_kwargs.
- _basesolver.preprocess() chains variable-fixing then bit-flip then zeroing; post_process_fixation() undoes bit-flips before fixation.
- _QuboSolverQuantum rejects negative off-diagonal coefficients unless bit-flip preprocessing is enabled, and after preprocessing if any remain.
- Add swiglpk dependency, tests, docs page and tutorial.