### PR TITLE
[Fix] Fix bitstring/cost mispairing in simulated annealing

### DIFF
--- a/qubosolver/solvers/classical/simulated_annealing.py
+++ b/qubosolver/solvers/classical/simulated_annealing.py
@@ -162,15 +162,22 @@ def simulated_annealing(
             temperature = 1e-12
 
     top_sol.sort(key=lambda t: t[0])
-    bitstrings_ = bitstrings.from_torch(torch.stack([b for (_, b) in top_sol], dim=0))
-    energies = vector.tensor([e for (e, _) in top_sol])
+    all_bits = bitstrings.from_torch(torch.stack([b for (_, b) in top_sol], dim=0))
+    all_energies = vector.tensor([e for (e, _) in top_sol])
 
+    # dedup defensively: inverse_indices[i] is the unique-row slot that row i
+    # maps to, so aligning energies with unique_bits is a scatter, not a
+    # gather — energies[inverse_indices] would silently mispair rows.
+    # Duplicate rows share the same energy, so any of them can be scattered in.
     unique_bits, inverse_indices, counts = torch.unique(
-        bitstrings_, dim=0, return_inverse=True, return_counts=True
+        all_bits, dim=0, return_inverse=True, return_counts=True
     )
-    energies = energies[inverse_indices]
+    energies = torch.empty(len(unique_bits), dtype=all_energies.dtype)
+    energies[inverse_indices] = all_energies
 
-    solution = Solution(
-        bitstrings=unique_bits, counts=counts, costs=energies
-    ).compute_probabilities()
+    solution = (
+        Solution(bitstrings=unique_bits, counts=counts, costs=energies)
+        .sort_by_cost()
+        .compute_probabilities()
+    )
     return solution

--- a/tests/solvers/test_simulated_annealing.py
+++ b/tests/solvers/test_simulated_annealing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import torch
+import copy
+
+from qubosolver import Instance, bitstring, torch_rng, solvers, matrix
+
+instance = Instance(
+    matrix.tensor(
+        [
+            [-2.0, 1.0, 0.0, -1.0, 0.0, 0.0],
+            [1.0, -3.0, 2.0, 0.0, 0.0, -1.0],
+            [0.0, 2.0, -1.0, 1.0, -2.0, 0.0],
+            [-1.0, 0.0, 1.0, -2.0, 1.0, 0.0],
+            [0.0, 0.0, -2.0, 1.0, -1.0, 2.0],
+            [0.0, -1.0, 0.0, 0.0, 2.0, -2.0],
+        ],
+    )
+)
+
+
+def test_simulated_annealing_costs_match_bitstrings() -> None:
+    """Every reported cost must correspond to x^T Q x of its own bitstring."""
+    start = bitstring.zeros(instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=5,
+        max_iter=3000,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    true_solution = copy.deepcopy(solution).compute_costs(instance.matrix)
+
+    torch.testing.assert_close(solution.costs, true_solution.costs)
+    torch.testing.assert_close(
+        solution.costs, torch.sort(solution.costs).values, atol=0.0, rtol=0.0
+    )


### PR DESCRIPTION
Fixes #230

torch.unique(..., return_inverse=True) followed by energies[inverse_indices] performed a gather where a scatter was required: inverse_indices[i] names the unique-row slot original row i maps to, so aligning energies with unique_bits means writing energies into that slot, not reading from it. The two coincide only when the row permutation is an involution, which is why the bug was seed-dependent.