### PR TITLE
[Fix] Reject bit-flip preprocessing results worse than a no-op

### DIFF
--- a/docs/content/classical/post-and-pre_processing/negative_coefficients.md
+++ b/docs/content/classical/post-and-pre_processing/negative_coefficients.md
@@ -52,7 +52,7 @@ Q = Instance(matrix.tensor(
     ]
 ))
 
-reduced = transforms.negative_bitflip.apply(Q, time_limit_s=5.0)
+reduced = transforms.negative_bitflip.apply(Q, time_limit_s=60.0)
 
 print(f"Flip vector: {reduced.flips}")
 print(f"Bitflip status: {reduced.status}")
@@ -109,7 +109,7 @@ Q_hard = Instance(matrix.tensor(
     ]
 ))
 
-reduced_hard = transforms.negative_bitflip.apply(Q_hard, time_limit_s=5.0)
+reduced_hard = transforms.negative_bitflip.apply(Q_hard, time_limit_s=60.0)
 
 print(f"Bitflip status: {reduced_hard.status}")
 print(f"Bitflip metrics: {json.dumps(reduced_hard.metrics, indent=4)}")

--- a/docs/tutorial/12-negative-coefficients-preprocessing.ipynb
+++ b/docs/tutorial/12-negative-coefficients-preprocessing.ipynb
@@ -168,7 +168,7 @@
     }
    ],
    "source": [
-    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=5.0)\n",
+    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=60.0)\n",
     "\n",
     "print(f\"Flip vector: {flipped_instance.flips}\")\n",
     "print(f\"Bitflip status: {flipped_instance.status}\")\n",
@@ -262,7 +262,7 @@
     }
    ],
    "source": [
-    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=5.0)\n",
+    "flipped_instance = transforms.negative_bitflip.apply(instance, time_limit_s=60.0)\n",
     "flipped_solution = solvers.brute_force(flipped_instance)\n",
     "solution_with_bitflip = transforms.negative_bitflip.unapply(flipped_solution, flipped_instance)\n",
     "\n",
@@ -396,7 +396,7 @@
     }
    ],
    "source": [
-    "flipped_hard_instance = transforms.negative_bitflip.apply(hard_instance, time_limit_s=5.0)\n",
+    "flipped_hard_instance = transforms.negative_bitflip.apply(hard_instance, time_limit_s=60.0)\n",
     "\n",
     "print(f\"Flip vector: {flipped_hard_instance.flips}\")\n",
     "print(f\"Bitflip status: {flipped_hard_instance.status}\")\n",

--- a/qubosolver/transforms/negative_bitflip.py
+++ b/qubosolver/transforms/negative_bitflip.py
@@ -331,9 +331,14 @@ def _solve_bitflip_preprocessing_glpk(
             elif return_code != 0:
                 status = f"GLPK_ERROR_{return_code}"
 
+            hint = (
+                " Consider increasing time_limit_s to give GLPK more time to find a solution."
+                if status == "TIME_LIMIT_NO_SOLUTION"
+                else ""
+            )
             logger.warning(
                 f"Bit-flip preprocessing ILP did not reach a feasible solution "
-                f"(status={status}); falling back to no-op flips."
+                f"(status={status}); falling back to no-op flips.{hint}"
             )
 
     except Exception:

--- a/qubosolver/transforms/negative_bitflip.py
+++ b/qubosolver/transforms/negative_bitflip.py
@@ -19,7 +19,7 @@ Typical usage:
 ```python
 import qubosolver.transforms.negative_bitflip as bitflip
 
-reduced = bitflip.apply(qubo_instance, time_limit_s=10.0)
+reduced = bitflip.apply(qubo_instance, time_limit_s=60.0)
 solution = solver.solve(reduced)
 full = bitflip.unapply(solution, reduced)
 ```
@@ -157,7 +157,7 @@ def _compute_negative_weight_metrics(
 def _solve_bitflip_preprocessing_glpk(
     Q: Matrix,
     *,
-    time_limit_s: float = 10.0,
+    time_limit_s: float = 60.0,
     eps: float = 0.0,
     log: bool = False,
 ) -> tuple[torch.Tensor, float, str]:
@@ -384,7 +384,7 @@ class Instance(qubosolver.Instance):
 def apply(
     qubo: qubosolver.Instance,
     *,
-    time_limit_s: float = 10.0,
+    time_limit_s: float = 60.0,
     eps: float = 0.0,
 ) -> Instance:
     """Solve the bit-flip ILP and apply the optimal flips to the QUBO matrix.

--- a/qubosolver/transforms/negative_bitflip.py
+++ b/qubosolver/transforms/negative_bitflip.py
@@ -28,6 +28,7 @@ full = bitflip.unapply(solution, reduced)
 from __future__ import annotations
 
 import copy
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -35,6 +36,8 @@ import torch
 
 import qubosolver
 from qubosolver.types import Solution, vector, Matrix, Bitstrings, Bitstring, bitstring
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -328,7 +331,16 @@ def _solve_bitflip_preprocessing_glpk(
             elif return_code != 0:
                 status = f"GLPK_ERROR_{return_code}"
 
+            logger.warning(
+                f"Bit-flip preprocessing ILP did not reach a feasible solution "
+                f"(status={status}); falling back to no-op flips."
+            )
+
     except Exception:
+        logger.warning(
+            "Bit-flip preprocessing ILP raised an exception; falling back to no-op flips.",
+            exc_info=True,
+        )
         flips = bitstring.zeros(n)
         status = "FAIL"
         objective_value = float("nan")
@@ -375,7 +387,10 @@ def apply(
     Wraps *qubo* in a bit-flip [`Instance`][], solves the negative-weight ILP
     with GLPK, and replaces the matrix with its flipped counterpart.  When
     *qubo* has no negative off-diagonal coefficient, the wrapper is returned
-    unchanged (``status`` stays ``"NONE"`` and ``flips`` stays all-zero).
+    unchanged (``status`` stays ``"NONE"`` and ``flips`` stays all-zero).  If
+    the solved flips would leave *more* negative weight than doing nothing
+    (a known GLPK edge case), they are rejected and replaced with a no-op
+    (``status`` becomes ``"REJECTED_WORSE_THAN_NOOP"``).
 
     Args:
         qubo: The QUBO instance to preprocess.
@@ -396,12 +411,25 @@ def apply(
         time_limit_s=time_limit_s,
         eps=eps,
     )
+    metrics = _compute_negative_weight_metrics(Q, flips, eps)
+
+    if metrics["neg_weight_reduction_pct"] < 0.0:
+        reduction_pct = metrics["neg_weight_reduction_pct"]
+        logger.warning(
+            f"Bit-flip preprocessing (status={status}) increased the remaining negative "
+            f"off-diagonal weight instead of reducing it ({reduction_pct:.2f}% change); "
+            f"falling back to no-op flips."
+        )
+        flips.fill_(0)
+        objective_value = float("nan")
+        status = "REJECTED_WORSE_THAN_NOOP"
+        metrics = _compute_negative_weight_metrics(Q, flips, eps)
 
     Q_flipped, offset = _transform_qubo_with_bitflips(Q, flips)
 
     instance._matrix = Q_flipped
     instance.flips = flips
-    instance.metrics = _compute_negative_weight_metrics(Q, flips, eps)
+    instance.metrics = metrics
     instance.metrics["objective_value"] = objective_value
     instance.status = status
     instance.offset = offset

--- a/qubosolver/transforms/zeroing.py
+++ b/qubosolver/transforms/zeroing.py
@@ -13,7 +13,7 @@ off-diagonal coefficient to zero and records which positions were zeroed on a
 import qubosolver.transforms.negative_bitflip as bitflip
 import qubosolver.transforms.zeroing as zeroing
 
-reduced = bitflip.apply(qubo_instance, time_limit_s=10.0)
+reduced = bitflip.apply(qubo_instance, time_limit_s=60.0)
 reduced = zeroing.apply(reduced)  # drop any negative coefficient bit flips could not remove
 print(reduced.zeroed_edges)       # (N, 2) tensor of zeroed (i, j) index pairs
 ```

--- a/tests/transforms/test_negative_bitflip.py
+++ b/tests/transforms/test_negative_bitflip.py
@@ -245,6 +245,79 @@ def test_glpk_infeasible_or_error_falls_back_to_noop_flips() -> None:
     check.equal(flips.shape[0], instance.size)
 
 
+def test_glpk_time_limit_warns_when_falling_back(caplog: pytest.LogCaptureFixture) -> None:
+    # When GLPK can't reach a feasible solution in time, apply() must degrade
+    # to no-op flips *and* surface a warning, so the failure is observable.
+    instance, _ = non_bipartisable_negative_qubo()
+
+    with caplog.at_level("WARNING", logger="qubosolver.transforms.negative_bitflip"):
+        flips, _, status = _solve_bitflip_preprocessing_glpk(instance.matrix, time_limit_s=0.0)
+
+    if status in ("TIME_LIMIT_NO_SOLUTION", "GLPK_ERROR_0"):
+        check.is_false(flips.any())
+        check.is_true(len(caplog.records) >= 1)
+
+
+def test_apply_rejects_flips_that_increase_negative_weight(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Regression test: GLPK can return flips that are individually "optimal"
+    # for its internal objective but still leave *more* negative weight than
+    # doing nothing (see issue #237). apply() must detect and reject this,
+    # falling back to a safe no-op rather than handing back a worse matrix.
+    instance, _ = non_bipartisable_negative_qubo()
+
+    # These flips are a genuine regression on this fixture: negative weight
+    # goes from 6.0 (no-op) to 7.0 (flipped).
+    worse_flips = bitstring.from_string("1100")
+
+    def _fake_solve(*args: Any, **kwargs: Any) -> tuple[Any, float, str]:
+        return worse_flips, 0.0, "OPTIMAL"
+
+    monkeypatch.setattr(
+        "qubosolver.transforms.negative_bitflip._solve_bitflip_preprocessing_glpk",
+        _fake_solve,
+    )
+
+    with caplog.at_level("WARNING", logger="qubosolver.transforms.negative_bitflip"):
+        flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    check.equal(flipped_instance.status, "REJECTED_WORSE_THAN_NOOP")
+    check.is_false(flipped_instance.flips.any())
+    check.is_nan(flipped_instance.metrics["objective_value"])
+    torch.testing.assert_close(flipped_instance.matrix, instance.matrix)
+    check.equal(
+        flipped_instance.metrics["neg_weight_after"],
+        flipped_instance.metrics["neg_weight_before"],
+    )
+    check.is_true(len(caplog.records) >= 1)
+
+
+def test_apply_keeps_flips_that_reduce_negative_weight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Sanity check for the new guard: a genuinely-improving flip vector must
+    # still be kept and must not be flagged as a regression.
+    instance, _ = non_bipartisable_negative_qubo()
+    good_flips = bitstring.from_string("0100")
+    expected_matrix, _ = _transform_qubo_with_bitflips(instance.matrix, good_flips)
+
+    def _fake_solve(*args: Any, **kwargs: Any) -> tuple[Any, float, str]:
+        return good_flips, 0.0, "OPTIMAL"
+
+    monkeypatch.setattr(
+        "qubosolver.transforms.negative_bitflip._solve_bitflip_preprocessing_glpk",
+        _fake_solve,
+    )
+
+    flipped_instance = transforms.negative_bitflip.apply(instance)
+
+    check.equal(flipped_instance.status, "OPTIMAL")
+    check.is_true(flipped_instance.flips.any())
+    torch.testing.assert_close(flipped_instance.matrix, expected_matrix)
+
+
 def test_glpk_solve_survives_internal_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     # If GLPK itself raises during the solve (e.g. a binding error), the
     # function must still return a usable (no-op) result instead of


### PR DESCRIPTION
GLPK can return flips that are locally optimal for its objective but still leave more negative off-diagonal weight than doing nothing. Detect this regression in apply(), fall back to no-op flips with a new REJECTED_WORSE_THAN_NOOP status, and log warnings on every fallback path (GLPK infeasible/timeout, GLPK exception, and this regression) so failures are observable.