### PR TITLE
Bump Renovate-managed CI tool versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           run: |
             hatch build
         - name: Publish to PyPI
-          uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+          uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         - name: Confirm deployment
           timeout-minutes: 5
           run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
         run: bandit -r qubosolver/ -c pyproject.toml -f sarif -o bandit-results.sarif || true  #TODO: remove 'true' once all warnings are fixed
       - name: Upload Bandit SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: bandit-results.sarif
 
@@ -69,9 +69,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          version: 0.11.18
+          version: 0.11.30
 
       - name: Install dependencies
         run: uv sync -p 3.12 -U
@@ -85,7 +85,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         continue-on-error: ${{ github.ref }} != 'refs/heads/main'
         with:
-          version: v0.71.0
+          version: v0.72.0
           scan-type: fs
           scan-ref: .
           format: table
@@ -95,7 +95,7 @@ jobs:
       - name: Run Trivy scan for upload # Never fails so the SARIF file is always available
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          version: v0.71.0
+          version: v0.72.0
           scan-type: fs
           scan-ref: .
           format: sarif
@@ -104,13 +104,14 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: trivy-results.sarif
 
       - name: Generate SBOM (CycloneDX)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          version: v0.72.0
           scan-type: fs
           scan-ref: .
           format: cyclonedx
@@ -127,6 +128,7 @@ jobs:
       - name: Submit Dependency Snapshot to GitHub Dependency Graph
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          version: v0.72.0
           scan-type: fs
           scan-ref: .
           format: github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,13 +91,15 @@ jobs:
         use-double-precision: [0, 1]
     steps:
         - name: Checkout main code and submodules
-          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+          uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install uv
-          uses: astral-sh/setup-uv@v6
+          uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+          with:
+            version: 0.11.30
         - name: Perform unit tests
           env:
             USE_DOUBLE_PRECISION: ${{ matrix.use-double-precision }}


### PR DESCRIPTION
Squashes 6 pending Renovate PRs:

pypa/gh-action-pypi-publish v1.14.1,
astral-sh/setup-uv v8.3.2 (pinned),
astral-sh/uv 0.11.30,
github/codeql-action v4.37.1,
aquasecurity/trivy v0.72.0.

Also pins the trivy and uv versions on steps that were previously left unpinned, for consistency with the rest of the workflow.