### PR TITLE
Rewrite simulated_annealing to track visit counts in a dict

### DIFF
--- a/docs/tutorial/07-classical-heuristics.ipynb
+++ b/docs/tutorial/07-classical-heuristics.ipynb
@@ -113,7 +113,7 @@
     "qubo = Instance(matrix=matrix.tensor([[-2.0, 1.0], [1.0, -2.0]]))\n",
     "rng = torch_rng(seed=0)\n",
     "\n",
-    "sa_solution = solvers.simulated_annealing(qubo, solvers.random_sampling(qubo, rng=rng).bitstrings[0], top_k=2)\n",
+    "sa_solution = solvers.simulated_annealing(qubo, solvers.random_sampling(qubo, rng=rng)[0].bitstring.unsqueeze(0), top_k=2)\n",
     "solution = solvers.tabu_search(qubo, sa_solution.bitstrings, time_limit=300.0)\n",
     "print(solution)"
    ]

--- a/qubosolver/config.py
+++ b/qubosolver/config.py
@@ -74,7 +74,6 @@ class ClassicalConfig(_Config):
         sa_cooling_rate (float, optional): Cooling rate - should be slightly below 1 (e.g., 0.95–0.99).
         sa_seed (int, optional): Random seed for reproducibility.
         sa_start (torch.Tensor | None, optional): Optional initial bitstring of shape (n,).
-        sa_energy_tol (float, optional): Energy tolerance for considering two solutions as equivalent.
         sa_time_limit (float): Maximum runtime in seconds for simulated annealing.
             Defaults to `float("inf")`, meaning no time limit.
         tabu_x0 (torch.Tensor | None, optional): The initial binary solution tensor of shape (n,).
@@ -97,7 +96,6 @@ class ClassicalConfig(_Config):
     sa_cooling_rate: float | None = None
     sa_seed: int | None = None
     sa_start: torch.Tensor | None = None
-    sa_energy_tol: float = 0.0
     sa_time_limit: float = float("inf")
 
     tabu_x0: torch.Tensor | None = None
@@ -148,7 +146,6 @@ class ClassicalConfig(_Config):
                     "sa_cooling_rate": self.sa_cooling_rate,
                     "sa_seed": self.sa_seed,
                     "sa_start": self.sa_start,
-                    "sa_energy_tol": self.sa_energy_tol,
                     "sa_time_limit": self.sa_time_limit,
                 }
             )

--- a/qubosolver/solvers/classical/_solver.py
+++ b/qubosolver/solvers/classical/_solver.py
@@ -97,7 +97,7 @@ class SimulatedAnnealingSolver(BaseClassicalSolver):
 
     Relevant :class:`~qubosolver.config.ClassicalConfig` fields:
     ``sa_seed``, ``sa_start``, ``sa_initial_temp``, ``sa_final_temp``,
-    ``sa_cooling_rate``, ``sa_energy_tol``, ``sa_time_limit``,
+    ``sa_cooling_rate``, ``sa_time_limit``,
     ``max_iter``, ``max_bitstrings``.
     """
 
@@ -120,19 +120,18 @@ class SimulatedAnnealingSolver(BaseClassicalSolver):
         else:
             start = self.config.sa_start
 
-        simulated_annealing_solution = solvers.simulated_annealing(
-            qubo=self.instance,
+        return solvers.simulated_annealing(
+            instance=self.instance,
             top_k=self.config.max_bitstrings,
             max_iter=self.config.max_iter,
             initial_temp=self.config.sa_initial_temp,
             final_temp=self.config.sa_final_temp,
             cooling_rate=self.config.sa_cooling_rate,
             rng=rng,
-            start=start,
-            energy_tol=self.config.sa_energy_tol,
+            start=start.unsqueeze(0),
             time_limit=self.config.sa_time_limit,
+            stats="per_run",
         )
-        return simulated_annealing_solution
 
 
 class TabuSearchSolver(BaseClassicalSolver):

--- a/qubosolver/solvers/classical/simulated_annealing.py
+++ b/qubosolver/solvers/classical/simulated_annealing.py
@@ -1,7 +1,8 @@
 """Simulated Annealing solver for QUBO problems.
 
-Implements a single-run bit-flip annealer that minimises
-the quadratic objective E(x) = xᵀ Q x over binary vectors x ∈ {0,1}ⁿ.
+Implements a bit-flip annealer that minimises the quadratic objective
+E(x) = xᵀ Q x over binary vectors x ∈ {0,1}ⁿ, run independently from each
+of a batch of starting points and merged into a single solution.
 
 The public entry point is `simulated_annealing`.  It is called by
 :class:`~qubosolver.solvers.SimulatedAnnealingSolver`.
@@ -10,43 +11,155 @@ The public entry point is `simulated_annealing`.  It is called by
 from __future__ import annotations
 
 import time
+import heapq
+import logging
+from dataclasses import dataclass
+from typing import Literal
 
 import torch
+from typing_extensions import overload
 
-from qubosolver import Instance, Solution, bitstrings, vector, Bitstring, torch_rng
+from qubosolver import (
+    Instance,
+    Solution,
+    bitstring,
+    bitstrings,
+    vector,
+    Bitstring,
+    Bitstrings,
+    torch_rng,
+    vectori,
+)
+
+logger = logging.getLogger(__name__)
 
 
-@torch.no_grad()
+@dataclass
+class _Data:
+    energy: float = float("inf")
+    count: int = 0
+
+
+def _to_key(bits: Bitstring) -> bytes:
+    return bytes(bits.tolist())
+
+
+def _from_key(key: bytes) -> Bitstring:
+    # Bitstring is always torch.int8, so this round-trips exactly through
+    # the same bytes produced by _to_key.
+    return torch.frombuffer(bytearray(key), dtype=bitstring.dtype())
+
+
+def _item_energy(item: tuple[bytes, _Data]) -> float:
+    return item[1].energy
+
+
+def _shrink(visited_solutions: dict[bytes, _Data], *, top_k: int) -> None:
+    # Mutates visited_solutions in place (no return value) so callers keep
+    # their reference valid instead of having to reassign it.
+    kept = heapq.nsmallest(top_k, visited_solutions.items(), key=_item_energy)
+    visited_solutions.clear()
+    visited_solutions.update(kept)
+
+
+# Built once at import time and shared as the default `rng` across the
+# overload stubs and the implementation below, so calls that omit `rng`
+# consistently reuse the same generator regardless of which overload mypy
+# picked, instead of each `def` capturing its own independent instance.
+_default_rng = torch_rng()
+
+
+@overload
 def simulated_annealing(
-    qubo: Instance,
-    start: Bitstring,
+    instance: Instance,
+    start: Bitstrings,
     *,
-    top_k: int = 5,
+    merge: Literal[True] = True,
+    top_k: int = 1,
     max_iter: int = 1000,
     initial_temp: float = 5.0,
     final_temp: float = 1e-3,
     cooling_rate: float | None = None,
-    energy_tol: float = 0.0,
     time_limit: float = float("inf"),
-    rng: torch.Generator = torch_rng(),
-) -> Solution:
-    """Run Simulated Annealing on a QUBO instance and return the best solutions found.
+    rng: torch.Generator = _default_rng,
+    stats: Literal["per_run", "full"] = "per_run",
+) -> Solution: ...
 
-    At each of `max_iter` steps a random bit is proposed for flipping.  The
-    flip is always accepted when it reduces the energy; otherwise it is
-    accepted with probability ``exp(-ΔE / T)``.  Energy updates are computed
-    incrementally in O(n) per step using the cached matrix-vector product ``Qx``.
 
-    Up to `top_k` unique lowest-energy bitstrings encountered during the run
-    are retained and returned, deduplicated by byte-hashing.
+@overload
+def simulated_annealing(
+    instance: Instance,
+    start: Bitstrings,
+    *,
+    merge: Literal[False],
+    top_k: int = 1,
+    max_iter: int = 1000,
+    initial_temp: float = 5.0,
+    final_temp: float = 1e-3,
+    cooling_rate: float | None = None,
+    time_limit: float = float("inf"),
+    rng: torch.Generator = _default_rng,
+    stats: Literal["per_run", "full"] = "per_run",
+) -> list[Solution]: ...
+
+
+@torch.no_grad()
+def simulated_annealing(
+    instance: Instance,
+    start: Bitstrings,
+    *,
+    merge: bool = True,
+    top_k: int = 1,
+    max_iter: int = 1000,
+    initial_temp: float = 5.0,
+    final_temp: float = 1e-3,
+    cooling_rate: float | None = None,
+    time_limit: float = float("inf"),
+    rng: torch.Generator = _default_rng,
+    stats: Literal["per_run", "full"] = "per_run",
+) -> Solution | list[Solution]:
+    """Run Simulated Annealing on a QUBO instance from each of a batch of starting points.
+
+    For each starting bitstring, at each of `max_iter` steps a random bit is
+    proposed for flipping.  The flip is always accepted when it reduces the
+    energy; otherwise it is accepted with probability ``exp(-ΔE / T)``.
+    Energy updates are computed incrementally in O(n) per step using the
+    cached matrix-vector product ``Qx``.
+
+    Up to `top_k` unique lowest-energy bitstrings encountered during each run
+    are retained, along with how many iterations were spent at each one
+    (whether or not the proposed flip at that iteration was accepted). The
+    runs are independent.  By default (``merge=True``) the per-start results
+    are merged into a single `Solution` via ``Solution.concat(...).deduplicate()``;
+    pass ``merge=False`` to instead get back the unmerged, one-per-start list.
+
+    Example:
+        Running a single start requires promoting it to a batch of size 1
+        first, via ``unsqueeze``:
+
+        ```python
+        solution = simulated_annealing(instance, start.unsqueeze(0))
+        ```
+
+        Passing ``merge=False`` returns the per-start results instead of a
+        single merged `Solution`:
+
+        ```python
+        solutions = simulated_annealing(instance, start, merge=False)
+        ```
 
     Args:
-        qubo: The QUBO instance to solve.  Its coefficient matrix is
+        instance: The QUBO instance to solve.  Its coefficient matrix is
             symmetrised internally as ``(Q + Qᵀ) / 2``.
-        start: Initial binary solution tensor of shape ``(n,)`` with values
-            in ``{0, 1}``.  The search begins from this configuration.
-        top_k: Maximum number of unique best solutions to keep, ordered by
-            ascending energy.
+        start: Batch of initial binary solutions, a tensor of shape
+            ``(k, n)`` with values in ``{0, 1}``.  One independent run is
+            performed per row.
+        merge: When ``True`` (default), merge the per-start results into a
+            single `Solution` via ``Solution.concat(...).deduplicate()``.
+            When ``False``, return the unmerged list of one `Solution` per
+            starting point (same order as `start`).
+        top_k: Maximum number of unique best solutions to keep per run,
+            ordered by ascending energy. Defaults to ``1``.
         max_iter: Number of bit-flip proposals to perform.
         initial_temp: Starting temperature T₀.  Higher values increase the
             probability of accepting uphill moves early in the search.
@@ -58,9 +171,6 @@ def simulated_annealing(
             T ← α·T at each step.  When ``None`` (default), α is derived
             automatically from `initial_temp`, `final_temp`, and `max_iter`
             so that the temperature reaches `final_temp` after `max_iter` steps.
-        energy_tol: Two solutions with energies differing by at most this
-            value are treated as equivalent when maintaining the top-k list.
-            Defaults to ``0.0`` (strict equality).
         time_limit: Wall-clock budget in seconds.  The algorithm stops early
             when either `max_iter` steps or the time limit is reached,
             whichever comes first.  Defaults to ``float("inf")`` (no limit).
@@ -68,9 +178,24 @@ def simulated_annealing(
             acceptance sampling.  Defaults to a module-level
             generator created once at import time; pass an explicit generator
             for reproducibility across calls.
+        stats: When ``"per_run"`` (default), each run's retained bitstrings
+            are counted as ``1`` instead of how many iterations were spent
+            at each one, before any merging. This is mainly meant for
+            ``top_k=1`` together with ``merge=True``, where the merged count
+            directly reflects how many of the runs converged on each
+            bitstring. With ``merge=True`` and ``top_k > 1``, or whenever a
+            bitstring is retained by more than one run, `deduplicate` sums
+            those per-run ``1``s, so counts on the merged result are
+            generally neither ``1`` nor uniform. When ``"full"``, counts
+            instead reflect how many iterations were spent at each
+            bitstring.
 
     Returns:
-        A solution containing up to `top_k` unique bitstrings sorted by ascending energy, with their costs, counts (how many times each was visited during the run), and probabilities.
+        When ``merge=True``, a single [`Solution`][] merging every start's
+        results.  When ``merge=False``, one [`Solution`][] per starting
+        point (same order as `start`).  Either way, each `Solution`
+        contains up to `top_k` unique bitstrings sorted by ascending energy,
+        with their costs, counts (see `stats`), and probabilities.
 
     Raises:
         ValueError: If ``top_k < 1``.
@@ -84,16 +209,14 @@ def simulated_annealing(
         raise ValueError("initial_temp must be > 0.")
     if cooling_rate is None and final_temp <= 0:
         raise ValueError("final_temp must be > 0 when cooling_rate is None.")
+    if stats == "per_run" and top_k > 1:
+        logger.info(
+            f"stats='per_run' with top_k={top_k}: per-run counts are set to 1, but merging "
+            "sums them across runs, so merged counts are not simply 1 per run."
+        )
 
-    Q = qubo.matrix
-    Q = 0.5 * (Q + Q.T)
-    n = int(Q.shape[0])
-
-    bits = start.to(device=Q.device, dtype=torch.uint8).clamp_(0, 1)
-
-    bits_f = bits.to(dtype=Q.dtype)
-    Qx = Q @ bits_f
-    energy = float(bits_f.dot(Qx))
+    n = instance.size
+    Q = instance.matrix
 
     # determine cooling rate alpha
     if max_iter <= 1:
@@ -103,80 +226,78 @@ def simulated_annealing(
         if not (0.0 < alpha < 1.0):
             raise ValueError("cooling_rate (alpha) must be in (0, 1).")
     else:
-        alpha = float((final_temp / initial_temp) ** (1.0 / (max_iter - 1)))
+        alpha = (final_temp / initial_temp) ** (1.0 / (max_iter - 1))
 
-    temperature = float(initial_temp)
+    solutions: list[Solution] = []
 
-    top_sol: list[tuple[float, torch.Tensor]] = []
-    seen: set[bytes] = set()
+    for b in start:
+        bits: Bitstring = b.detach().clone()
 
-    def key_from_bits(b: torch.Tensor) -> bytes:
-        return bytes(b.cpu().tolist())
+        Qx = Q @ bits.to(Q)
+        energy = float(bits.to(Q).dot(Qx))
 
-    def maybe_insert(b_u8: torch.Tensor, e: float) -> None:
-        k = key_from_bits(b_u8)
-        if k in seen:
-            return
-        top_sol.append((e, b_u8.cpu().clone()))
-        top_sol.sort(key=lambda t: t[0])
-        if len(top_sol) > top_k:
-            cutoff = top_sol[top_k - 1][0]
-            kept = [pair for pair in top_sol if pair[0] <= cutoff + energy_tol]
-            top_sol[:] = kept[:top_k]
-        seen.clear()
-        for _, bb in top_sol:
-            seen.add(key_from_bits(bb))
+        temperature: float = initial_temp
 
-    maybe_insert(bits, energy)
+        visited_solutions: dict[bytes, _Data] = {}
+        visited_solutions[_to_key(bits)] = _Data(energy, 1)
 
-    deadline = time.perf_counter() + time_limit
+        deadline = time.perf_counter() + time_limit
 
-    for _ in range(max_iter):
-        if time.perf_counter() >= deadline:
-            break
+        for _ in range(max_iter):
+            if time.perf_counter() >= deadline:
+                break
 
-        i = int(torch.randint(0, n, (1,), generator=rng).item())
-        xi = int(bits[i].item())
+            i = int(torch.randint(0, n, (1,), generator=rng).item())
+            xi = int(bits[i].item())
 
-        # ΔE = (1 - 2xi) * (Q_ii + 2*(Qx_i - Q_ii*xi))
-        Qii = float(Q[i, i].item())
-        Qx_i = float(Qx[i].item())
-        dE = (1 - 2 * xi) * (Qii + 2.0 * (Qx_i - Qii * xi))
+            # ΔE = (1 - 2xi) * (Q_ii + 2*(Qx_i - Q_ii*xi))
+            Qii = float(Q[i, i].item())
+            Qx_i = float(Qx[i].item())
+            dE = (1 - 2 * xi) * (Qii + 2.0 * (Qx_i - Qii * xi))
 
-        accept = (dE <= 0.0) or (
-            torch.rand((), generator=rng).item() < torch.exp(torch.tensor(-dE / temperature)).item()
+            accept = (dE <= 0.0) or (
+                torch.rand((), generator=rng).item()
+                < torch.exp(torch.tensor(-dE / temperature)).item()
+            )
+            if accept:
+                new_xi = 1 - xi
+                diff = float(new_xi - xi)
+                bits[i] = new_xi
+                energy += dE
+                Qx += diff * Q[:, i]
+
+            key = _to_key(bits)
+            sol = visited_solutions.setdefault(key, _Data(energy, 0))
+            sol.count += 1
+
+            # Most inserts are one-off bitstrings that will never make the
+            # top_k cut, so the dict keeps growing between shrinks regardless
+            # of top_k. The "+100" gives it room to grow before paying for a
+            # shrink; "2 *" just keeps that room proportional once top_k is
+            # itself large (e.g. top_k=1000).
+            limit = max(2 * top_k, top_k + 100)
+            if len(visited_solutions) >= limit:
+                _shrink(visited_solutions, top_k=top_k)
+
+            temperature *= alpha
+            if temperature < 1e-12:
+                temperature = 1e-12
+
+        _shrink(visited_solutions, top_k=top_k)
+
+        counts = vectori.tensor([s.count for s in visited_solutions.values()])
+        if stats == "per_run":
+            counts.fill_(1)
+
+        unique_bits = torch.stack([_from_key(key) for key in visited_solutions.keys()])
+        solution = Solution(
+            bitstrings=bitstrings.from_torch(unique_bits),
+            costs=vector.tensor([s.energy for s in visited_solutions.values()]),
+            counts=counts,
         )
-        if accept:
-            new_xi = 1 - xi
-            diff = float(new_xi - xi)
-            bits[i] = new_xi
-            bits_f[i] = float(new_xi)
-            energy += dE
-            Qx += diff * Q[:, i]
-            if len(top_sol) < top_k or energy <= top_sol[-1][0] + energy_tol:
-                maybe_insert(bits, energy)
 
-        temperature *= alpha
-        if temperature < 1e-12:
-            temperature = 1e-12
+        solutions.append(solution.sort_by_cost().compute_probabilities())
 
-    top_sol.sort(key=lambda t: t[0])
-    all_bits = bitstrings.from_torch(torch.stack([b for (_, b) in top_sol], dim=0))
-    all_energies = vector.tensor([e for (e, _) in top_sol])
-
-    # dedup defensively: inverse_indices[i] is the unique-row slot that row i
-    # maps to, so aligning energies with unique_bits is a scatter, not a
-    # gather — energies[inverse_indices] would silently mispair rows.
-    # Duplicate rows share the same energy, so any of them can be scattered in.
-    unique_bits, inverse_indices, counts = torch.unique(
-        all_bits, dim=0, return_inverse=True, return_counts=True
-    )
-    energies = torch.empty(len(unique_bits), dtype=all_energies.dtype)
-    energies[inverse_indices] = all_energies
-
-    solution = (
-        Solution(bitstrings=unique_bits, counts=counts, costs=energies)
-        .sort_by_cost()
-        .compute_probabilities()
-    )
-    return solution
+    if merge:
+        return Solution.concat(solutions).deduplicate()
+    return solutions

--- a/qubosolver/types/bitstring.py
+++ b/qubosolver/types/bitstring.py
@@ -17,6 +17,7 @@ from typing import Any
 import torch
 from . import linalg, vector
 from .linalg import Bitstring
+from .random import torch_rng
 
 
 def dtype() -> torch.dtype:
@@ -91,3 +92,19 @@ def to_string(bitstring: Bitstring) -> str:
         A string of '0' and '1' characters.
     """
     return "".join(str(b.item()) for b in bitstring.flatten())
+
+
+def rand(
+    n: int, *, device: torch.device = device(), rng: torch.Generator = torch_rng()
+) -> Bitstring:
+    """Creates a bitstring of length *n* with independent uniformly random bits.
+
+    Args:
+        n: Length of the bitstring.
+        device: Torch device for the tensor.
+        rng: PyTorch random number generator controlling the sampling.
+
+    Returns:
+        A 1-D ``int8`` tensor of 0s and 1s.
+    """
+    return torch.randint(0, 2, (n,), generator=rng, device=device, dtype=dtype())

--- a/qubosolver/types/bitstrings.py
+++ b/qubosolver/types/bitstrings.py
@@ -20,6 +20,7 @@ from typing import Any, Sequence
 import torch
 from .linalg import Bitstrings
 from . import bitstring
+from .random import torch_rng
 
 
 def dtype() -> torch.dtype:
@@ -106,3 +107,20 @@ def to_strings(bitstrings: Bitstrings) -> list[str]:
         A list of *n* strings, each of length *m*, representing each row of the tensor.
     """
     return [bitstring.to_string(b) for b in bitstrings]
+
+
+def rand(
+    count: int, n_bits: int, *, device: torch.device = device(), rng: torch.Generator = torch_rng()
+) -> Bitstrings:
+    """Creates a 2-D bitstrings tensor with independent uniformly random bits.
+
+    Args:
+        count: Number of bitstrings (rows).
+        n_bits: Length of each bitstring (columns).
+        device: Torch device for the tensor.
+        rng: PyTorch random number generator controlling the sampling.
+
+    Returns:
+        A 2-D ``int8`` tensor of shape ``(count, n_bits)`` containing 0s and 1s.
+    """
+    return torch.randint(0, 2, (count, n_bits), generator=rng, device=device, dtype=dtype())

--- a/qubosolver/types/solution.py
+++ b/qubosolver/types/solution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import torch
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing_extensions import Self
 
 from ._checks import debug_runtime_typecheck
@@ -36,6 +36,7 @@ class SingleSolution:
 
     bitstring: Bitstring
     cost: float = float("inf")
+    count: int = 0
     probability: float = 0.0
 
     @property
@@ -118,6 +119,7 @@ class Solution:
             Snapshot of the candidate at *idx*.
         """
         solution = SingleSolution(self.bitstrings[idx])
+        solution.count = int(self.counts[idx].item())
         if self.costs.numel() > 0:
             solution.cost = self.costs[idx].item()
         if self.probabilities.numel() > 0:
@@ -199,6 +201,153 @@ class Solution:
         if self.probabilities.numel() > 0:
             self.probabilities = self.probabilities[sorted_indices]
         return self
+
+    def truncate(self, k: int) -> Self:
+        """Keep only the first *k* candidates in-place.
+
+        Slices `bitstrings`, `costs`, `counts`, and `probabilities`
+        (whichever are non-empty) down to their first *k* rows. Does not
+        sort or deduplicate first; combine with `sort_by_cost` /
+        `deduplicate` as needed, e.g. ``solution.sort_by_cost().truncate(1)``
+        to keep the best candidate.
+
+        Args:
+            k: Number of candidates to keep. When ``k >= len(self)``, this
+                is a no-op.
+
+        Returns:
+            The same [`Solution`][] instance, allowing method chaining.
+
+        Raises:
+            ValueError: If `probabilities` is non-empty while
+                `counts` is empty.
+
+        Note:
+            When both are populated, `probabilities` are recomputed
+            from the truncated `counts` (via `compute_probabilities`)
+            rather than merely sliced, so they still sum to 1.
+        """
+        if self.probabilities.numel() > 0 and self.counts.numel() == 0:
+            raise ValueError("Solution.truncate() requires counts when probabilities is populated")
+
+        self.bitstrings = self.bitstrings[:k]
+        if self.costs.numel() > 0:
+            self.costs = self.costs[:k]
+        if self.counts.numel() > 0:
+            self.counts = self.counts[:k]
+            if self.probabilities.numel() > 0:
+                self.compute_probabilities()
+        return self
+
+    def deduplicate(self) -> Self:
+        """Collapse duplicate bitstrings in-place, summing their counts.
+
+        Rows sharing the same bitstring are merged into a single row:
+        `counts` are summed, the minimum `cost` is kept, and
+        `probabilities` are recomputed from the new totals. The result
+        is sorted by cost.
+
+        When `counts` is empty (not yet populated), count-summing and
+        probability recomputation are skipped, and `counts` /
+        `probabilities` remain empty on the result. Likewise, when
+        `costs` is empty, cost reduction and cost-based sorting are
+        skipped, and `costs` remains empty on the result.
+
+        Returns:
+            The same [`Solution`][] instance, allowing method chaining.
+
+        Note:
+            When several rows share a bitstring, the minimum of their
+            `costs` is kept. This is only meaningful if those costs
+            were all computed from the same QUBO instance (same
+            `matrix` passed to `compute_costs`); the caller is
+            responsible for ensuring that, since this method does not
+            verify it.
+        """
+        if not self:
+            return self
+
+        unique_bitstrings, inverse = self.bitstrings.unique(dim=0, return_inverse=True)
+        n = unique_bitstrings.shape[0]
+        self.bitstrings = unique_bitstrings
+
+        if self.counts.numel() > 0:
+            self.counts = vectori.zeros(n).scatter_reduce(
+                dim=0, index=inverse, src=self.counts, reduce="sum", include_self=False
+            )
+
+        if self.costs.numel() > 0:
+            self.costs = vector.zeros(n).scatter_reduce(
+                dim=0, index=inverse, src=self.costs, reduce="amin", include_self=False
+            )
+            self.sort_by_cost()
+
+        if self.counts.numel() > 0:
+            self.compute_probabilities()
+
+        return self
+
+    @staticmethod
+    def concat(solutions: Iterable[Solution], *, unit_counts: bool = False) -> Solution:
+        """Concatenate several solutions into a new one, without deduplication.
+
+        Concatenates `bitstrings`, `costs`, `counts`, and
+        `probabilities` from every solution in *solutions*. Duplicate
+        bitstrings, if any, are kept as separate rows — call
+        `deduplicate` on the result to collapse them:
+
+        ```python
+        merged = Solution.concat([a, b]).deduplicate()
+        ```
+
+        Args:
+            solutions: Solutions to concatenate. Empty solutions (no
+                bitstrings) are skipped. Among the remaining solutions,
+                each of `costs`, `counts`, and `probabilities` must be
+                either populated on all of them or empty on all of them
+                — mixing populated and empty for the same field raises
+                `ValueError`.
+            unit_counts: When ``True``, set `counts` to ``1`` for every
+                concatenated candidate instead of concatenating their
+                original counts — useful when each candidate should count
+                as a single vote once merged, e.g.
+                ``Solution.concat(solutions, unit_counts=True).deduplicate()``.
+                `probabilities`, if populated, are recomputed from the
+                resulting `counts` rather than concatenated, so they
+                still sum to 1.
+
+        Returns:
+            A new [`Solution`][] containing every candidate from every
+            solution, or an empty [`Solution`][] if *solutions* is empty
+            or contains only empty solutions.
+        """
+        non_empty = [solution for solution in solutions if solution]
+        if not non_empty:
+            return Solution()
+
+        for field in ("costs", "counts", "probabilities"):
+            populated = [getattr(s, field).numel() > 0 for s in non_empty]
+            if any(populated) and not all(populated):
+                raise ValueError(
+                    f"Solution.concat() requires {field} to be either populated on "
+                    f"every solution or empty on every solution, not a mix of both"
+                )
+
+        bitstrings = torch.cat([s.bitstrings for s in non_empty], dim=0)
+        probabilities_populated = non_empty[0].probabilities.numel() > 0
+        if unit_counts:
+            counts = vectori.zeros(bitstrings.shape[0]).fill_(1)
+        else:
+            counts = torch.cat([s.counts for s in non_empty], dim=0)
+
+        result = Solution(
+            bitstrings=bitstrings,
+            costs=torch.cat([s.costs for s in non_empty], dim=0),
+            counts=counts,
+        )
+        if probabilities_populated:
+            result.compute_probabilities()
+        return result
 
     @staticmethod
     def from_results(results: Results, *, instance: Instance = Instance()) -> Solution:

--- a/tests/integration/test_functional.py
+++ b/tests/integration/test_functional.py
@@ -226,10 +226,14 @@ def test_classical_solve(
         solution = solvers.tabu_search(effective_qubo, solution.bitstrings)
     elif solving_method == "sa":
         solution = solvers.random_sampling(effective_qubo, rng=rng, max_bitstrings=1)
-        solution = solvers.simulated_annealing(effective_qubo, solution.bitstrings[0], top_k=1)
+        solution = solvers.simulated_annealing(
+            effective_qubo, solution[0].bitstring.unsqueeze(0), top_k=1
+        )
     elif solving_method == "sa+tabu":
         solution = solvers.random_sampling(effective_qubo, rng=rng, max_bitstrings=1)
-        solution = solvers.simulated_annealing(effective_qubo, solution.bitstrings[0], top_k=1)
+        solution = solvers.simulated_annealing(
+            effective_qubo, solution[0].bitstring.unsqueeze(0), top_k=1
+        )
         solution = solvers.tabu_search(effective_qubo, solution.bitstrings)
     elif solving_method == "random":
         solution = solvers.random_sampling(effective_qubo, rng=rng)

--- a/tests/solvers/test_classical_solver.py
+++ b/tests/solvers/test_classical_solver.py
@@ -82,8 +82,8 @@ def test_qubo_solver_sa_or_tabu(
     check.equal(solution.bitstrings.shape[1], simple_qubo_instance.size)
     check.equal(len(solution.counts), len(solution.bitstrings))
     check.equal(len(solution.probabilities), len(solution.bitstrings))
-    # random_sampling draws max_bitstrings uniformly at random and dedups them,
-    # so the total count can be less than max_bitstrings if a bitstring is drawn twice.
+    # SA uses stats='per_run', so it counts each retained bitstring once,
+    # bounded by max_bitstrings, same as tabu search.
     check.less_equal(solution.counts.sum().item(), max_bitstrings)
     check.almost_equal(solution.probabilities.sum().item(), 1.0)
 

--- a/tests/solvers/test_simulated_annealing.py
+++ b/tests/solvers/test_simulated_annealing.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
+import inspect
+
+import pytest
+import pytest_check as check
 import torch
 import copy
+from typing_extensions import assert_type, get_overloads
 
-from qubosolver import Instance, bitstring, torch_rng, solvers, matrix
+from qubosolver import (
+    Instance,
+    Solution,
+    bitstring,
+    torch_rng,
+    solvers,
+    matrix,
+    bitstrings,
+    vectori,
+)
+from qubosolver.solvers.classical.simulated_annealing import (
+    _Data,
+    _to_key,
+    _from_key,
+    _item_energy,
+    _shrink,
+    simulated_annealing,
+)
 
-instance = Instance(
+instance_symmetric = Instance(
     matrix.tensor(
         [
             [-2.0, 1.0, 0.0, -1.0, 0.0, 0.0],
@@ -18,10 +40,98 @@ instance = Instance(
     )
 )
 
+instance_small = Instance(
+    matrix.tensor(
+        [
+            [1.0, 3.0, -1.0, 0.5],
+            [3.0, -2.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.5, -1.5],
+            [0.5, 0.0, -1.5, -1.0],
+        ],
+    )
+)
 
-def test_simulated_annealing_costs_match_bitstrings() -> None:
+instances = [instance_symmetric, instance_small]
+instance_ids = ["6var", "4var"]
+
+
+def test_to_key_from_key_round_trip() -> None:
+    """_from_key must reconstruct the exact bitstring given to _to_key."""
+    bits = bitstring.from_string("10110")
+
+    key = _to_key(bits)
+    restored = _from_key(key)
+
+    torch.testing.assert_close(restored, bits)
+
+
+def test_to_key_distinguishes_different_bitstrings() -> None:
+    """Different bitstrings must map to different keys."""
+    a = _to_key(bitstring.from_string("100"))
+    b = _to_key(bitstring.from_string("001"))
+
+    check.not_equal(a, b)
+
+
+def test_to_key_equal_for_equal_bitstrings() -> None:
+    """Two tensors with the same values must map to the same key."""
+    a = _to_key(bitstring.from_string("101"))
+    b = _to_key(bitstring.from_string("101"))
+
+    check.equal(a, b)
+
+
+def test_item_energy_reads_data_energy() -> None:
+    """_item_energy must extract the energy field of the (key, _Data) pair."""
+    item = (b"\x00", _Data(energy=-3.5, count=2))
+
+    check.equal(_item_energy(item), -3.5)
+
+
+def test_shrink_keeps_top_k_lowest_energy() -> None:
+    """_shrink must retain only the top_k lowest-energy entries."""
+    visited_solutions = {
+        b"a": _Data(energy=3.0, count=1),
+        b"b": _Data(energy=1.0, count=1),
+        b"c": _Data(energy=2.0, count=1),
+        b"d": _Data(energy=0.5, count=1),
+    }
+
+    _shrink(visited_solutions, top_k=2)
+
+    check.equal(set(visited_solutions.keys()), {b"d", b"b"})
+
+
+def test_shrink_mutates_in_place() -> None:
+    """_shrink must mutate the passed-in dict rather than returning a new one."""
+    visited_solutions = {
+        b"a": _Data(energy=3.0, count=1),
+        b"b": _Data(energy=1.0, count=1),
+    }
+    original = visited_solutions
+
+    _shrink(visited_solutions, top_k=1)
+
+    check.is_(visited_solutions, original)
+    check.equal(len(visited_solutions), 1)
+
+
+def test_shrink_noop_when_already_within_top_k() -> None:
+    """_shrink must not drop entries when the dict already fits within top_k."""
+    visited_solutions = {
+        b"a": _Data(energy=3.0, count=1),
+        b"b": _Data(energy=1.0, count=1),
+    }
+
+    _shrink(visited_solutions, top_k=5)
+
+    check.equal(set(visited_solutions.keys()), {b"a", b"b"})
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_costs_match_bitstrings(instance: Instance) -> None:
     """Every reported cost must correspond to x^T Q x of its own bitstring."""
-    start = bitstring.zeros(instance.size)
+    start = bitstrings.zeros(1, instance.size)
     rng = torch_rng(0)
 
     solution = solvers.simulated_annealing(
@@ -40,3 +150,485 @@ def test_simulated_annealing_costs_match_bitstrings() -> None:
     torch.testing.assert_close(
         solution.costs, torch.sort(solution.costs).values, atol=0.0, rtol=0.0
     )
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_solution_is_internally_consistent(instance: Instance) -> None:
+    """The returned Solution must pass the full consistency check (shapes, costs,
+    sortedness, no duplicate bitstrings, positive integer counts, probabilities
+    matching normalised counts)."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=5,
+        max_iter=3000,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    check.is_true(solution.check_consistency(instance, throw=True))
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_counts_sum_to_visits(instance: Instance) -> None:
+    """Counts must be strictly positive integers, and their total must be at
+    least the number of returned bitstrings."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=3,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    check.is_true(torch.all(solution.counts > 0).item())
+    check.greater_equal(solution.counts.sum().item(), len(solution))
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_respects_top_k(instance: Instance) -> None:
+    """The number of returned solutions never exceeds top_k."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=2,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    check.is_in(len(solution), [1, 2])
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_deterministic_with_seeded_rng(instance: Instance) -> None:
+    """Two runs with the same seed must produce identical solutions."""
+    start = bitstrings.zeros(1, instance.size)
+
+    solution_a = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=4,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(565111),
+    )
+    solution_b = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=4,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(565111),
+    )
+
+    torch.testing.assert_close(solution_a.bitstrings, solution_b.bitstrings)
+    torch.testing.assert_close(solution_a.costs, solution_b.costs, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(solution_a.counts, solution_b.counts)
+    torch.testing.assert_close(
+        solution_a.probabilities, solution_b.probabilities, atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_zero_max_iter_returns_start(instance: Instance) -> None:
+    """With max_iter=0, only the starting bitstring is returned."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=5,
+        max_iter=0,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    check.equal(len(solution), 1)
+    check.equal(solution[0].string, bitstring.to_string(start))
+    check.equal(solution[0].count, 1)
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_zero_time_limit_returns_start(instance: Instance) -> None:
+    """An exhausted time budget stops the loop before any iteration runs."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=5,
+        max_iter=1000,
+        initial_temp=4.0,
+        final_temp=0.05,
+        time_limit=0.0,
+        rng=rng,
+    )
+
+    check.equal(len(solution), 1)
+    check.equal(solution[0].string, bitstring.to_string(start))
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_explicit_cooling_rate_used(instance: Instance) -> None:
+    """When cooling_rate is provided, final_temp is ignored and no error is
+    raised even if final_temp is invalid (<= 0)."""
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=3,
+        max_iter=200,
+        initial_temp=4.0,
+        final_temp=-1.0,
+        cooling_rate=0.9,
+        rng=rng,
+    )
+
+    check.is_true(solution.check_consistency(instance, throw=True))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"top_k": 0}, "top_k"),
+        ({"top_k": -1}, "top_k"),
+        ({"initial_temp": 0.0}, "initial_temp"),
+        ({"initial_temp": -1.0}, "initial_temp"),
+        ({"final_temp": 0.0}, "final_temp"),
+        ({"final_temp": -1.0}, "final_temp"),
+        ({"cooling_rate": 0.0}, "cooling_rate"),
+        ({"cooling_rate": 1.0}, "cooling_rate"),
+        ({"cooling_rate": -0.5}, "cooling_rate"),
+        ({"cooling_rate": 1.5}, "cooling_rate"),
+    ],
+)
+def test_simulated_annealing_raises_on_invalid_arguments(kwargs: dict, match: str) -> None:
+    start = bitstrings.zeros(1, instance_symmetric.size)
+
+    with pytest.raises(ValueError, match=match):
+        solvers.simulated_annealing(instance_symmetric, start, rng=torch_rng(658), **kwargs)
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_merge_false_returns_one_solution_per_start(
+    instance: Instance,
+) -> None:
+    """With merge=False, one Solution must be returned per row of `start`,
+    in the same order, none of them merged with the others."""
+    start = bitstrings.zeros(3, instance.size)
+    rng = torch_rng(0)
+
+    solutions = solvers.simulated_annealing(
+        instance,
+        start,
+        merge=False,
+        top_k=2,
+        max_iter=100,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+    )
+
+    check.equal(len(solutions), 3)
+    for solution in solutions:
+        check.is_true(solution.check_consistency(instance, throw=True))
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_merge_true_matches_manual_concat_and_deduplicate(
+    instance: Instance,
+) -> None:
+    """merge=True (the default) must be equivalent to merging the merge=False
+    per-start results via Solution.concat(...).deduplicate(), as documented
+    on the function."""
+    start = bitstrings.rand(4, instance.size, rng=torch_rng(574))
+    top_k = 3
+
+    merged_solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=top_k,
+        max_iter=200,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(7874),
+    )
+    solutions = solvers.simulated_annealing(
+        instance,
+        start,
+        merge=False,
+        top_k=top_k,
+        max_iter=200,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(7874),
+    )
+    manually_merged = Solution.concat(solutions).deduplicate()
+
+    check.is_true(merged_solution.check_consistency(instance, throw=True))
+    torch.testing.assert_close(merged_solution.bitstrings, manually_merged.bitstrings)
+    torch.testing.assert_close(merged_solution.costs, manually_merged.costs, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(merged_solution.counts, manually_merged.counts)
+
+
+def test_simulated_annealing_empty_start_merge_false_returns_empty_list() -> None:
+    """An empty batch of starts must produce an empty list, with no runs
+    performed, when merge=False."""
+    start = bitstrings.zeros(0, instance_symmetric.size)
+
+    solutions = solvers.simulated_annealing(
+        instance_symmetric, start, merge=False, rng=torch_rng(0)
+    )
+
+    check.equal(solutions, [])
+
+
+def test_simulated_annealing_empty_start_merge_true_returns_empty_solution() -> None:
+    """An empty batch of starts must produce an empty Solution, with no runs
+    performed, when merge=True (the default)."""
+    start = bitstrings.zeros(0, instance_symmetric.size)
+
+    solution = solvers.simulated_annealing(instance_symmetric, start, rng=torch_rng(0))
+
+    check.is_false(solution)
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_stats_per_run_sets_single_run_counts_to_one(
+    instance: Instance,
+) -> None:
+    """With a single run (one start), stats='per_run' must set every
+    returned bitstring's count to 1, regardless of how many iterations were
+    actually spent at it. With multiple runs merged together, counts are not
+    uniformly 1 -- see
+    test_simulated_annealing_stats_per_run_merged_counts_reflect_run_agreement.
+    """
+    start = bitstrings.zeros(1, instance.size)
+    rng = torch_rng(0)
+
+    solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=3,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=rng,
+        stats="per_run",
+    )
+    expected_counts = vectori.zeros(len(solution)).fill_(1)
+    torch.testing.assert_close(solution.counts, expected_counts)
+
+
+def test_simulated_annealing_stats_per_run_merged_counts_reflect_run_agreement() -> None:
+    """With stats='per_run', top_k=1, and merge=True (default), each run
+    contributes a single bitstring with count 1; after merging, a
+    bitstring's count is the number of runs that converged on it -- neither
+    always 1 nor uniform across bitstrings."""
+    start = bitstrings.rand(8, instance_symmetric.size, rng=torch_rng(11))
+
+    solution = solvers.simulated_annealing(
+        instance_symmetric,
+        start,
+        top_k=1,
+        max_iter=300,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(0),
+        stats="per_run",
+    )
+
+    check.equal(solution.counts.sum().item(), 8)
+    check.is_true(torch.all(solution.counts >= 1).item())
+
+
+def test_simulated_annealing_stats_per_run_top_k_one_merge_true_matches_manual_equivalent() -> None:
+    """merge=True, top_k=1, stats='per_run' must be equivalent to running
+    with merge=False, top_k>1, stats='full' (the default), then per start
+    keeping only the best bitstring (truncate(1) -- each per-start Solution
+    is already sorted by cost, so its first row is its best), concatenating
+    with unit_counts=True (each surviving bitstring counts as a single vote,
+    matching stats='per_run'), and deduplicating.
+
+    This also shows how to get the condensed, single-best-per-run result that
+    most other optimization libraries return by default, while still running
+    with stats='full' to keep the complete per-run results available if
+    needed."""
+    start = bitstrings.rand(8, instance_symmetric.size, rng=torch_rng(1350))
+
+    per_run_solution = solvers.simulated_annealing(
+        instance_symmetric,
+        start,
+        max_iter=300,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(0),
+    )
+
+    solutions = solvers.simulated_annealing(
+        instance_symmetric,
+        start,
+        merge=False,
+        top_k=3,
+        max_iter=300,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(0),
+        stats="full",
+    )
+    manually_equivalent = Solution.concat(
+        [solution.truncate(1) for solution in solutions], unit_counts=True
+    ).deduplicate()
+
+    torch.testing.assert_close(per_run_solution.bitstrings, manually_equivalent.bitstrings)
+    torch.testing.assert_close(
+        per_run_solution.costs, manually_equivalent.costs, atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(per_run_solution.counts, manually_equivalent.counts)
+    torch.testing.assert_close(
+        per_run_solution.probabilities, manually_equivalent.probabilities, atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.parametrize("instance", instances, ids=instance_ids)
+def test_simulated_annealing_stats_per_run_is_default(instance: Instance) -> None:
+    """Omitting stats must be equivalent to passing stats='per_run' explicitly."""
+    start = bitstrings.zeros(1, instance.size)
+
+    default_solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=3,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(23),
+    )
+    explicit_per_run_solution = solvers.simulated_annealing(
+        instance,
+        start,
+        top_k=3,
+        max_iter=500,
+        initial_temp=4.0,
+        final_temp=0.05,
+        rng=torch_rng(23),
+        stats="per_run",
+    )
+
+    torch.testing.assert_close(default_solution.counts, explicit_per_run_solution.counts)
+
+
+def test_simulated_annealing_stats_per_run_top_k_above_one_logs_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """stats='per_run' with top_k > 1 must emit an info-level log noting that
+    merged counts won't simply be 1 per run."""
+    start = bitstrings.zeros(1, instance_symmetric.size)
+
+    with caplog.at_level("INFO", logger="qubosolver.solvers.classical.simulated_annealing"):
+        solvers.simulated_annealing(
+            instance_symmetric,
+            start,
+            top_k=2,
+            max_iter=50,
+            initial_temp=4.0,
+            final_temp=0.05,
+            rng=torch_rng(0),
+            stats="per_run",
+        )
+
+    check.is_true(any("per_run" in record.message for record in caplog.records))
+
+
+def test_simulated_annealing_stats_per_run_top_k_one_does_not_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """stats='per_run' with top_k=1 (the intended, unambiguous usage) must
+    not emit the top_k > 1 caveat log."""
+    start = bitstrings.zeros(1, instance_symmetric.size)
+
+    with caplog.at_level("INFO", logger="qubosolver.solvers.classical.simulated_annealing"):
+        solvers.simulated_annealing(
+            instance_symmetric,
+            start,
+            top_k=1,
+            max_iter=50,
+            initial_temp=4.0,
+            final_temp=0.05,
+            rng=torch_rng(12),
+            stats="per_run",
+        )
+
+    check.equal(caplog.records, [])
+
+
+def test_simulated_annealing_overloads_match_implementation_signature() -> None:
+    """Every @overload stub of simulated_annealing must declare exactly the
+    same parameters, with the same defaults, as the real implementation, so
+    adding/removing/renaming a parameter -- or changing its default -- on
+    only one of the three cannot silently drift from the others.
+
+    `merge` is exempted from the default-value check: it intentionally has
+    no default in the merge=False overload (it must be passed explicitly to
+    select that overload), unlike the impl and the merge=True overload
+    where it defaults to True.
+    """
+    impl_params = inspect.signature(simulated_annealing).parameters
+    overloads = get_overloads(simulated_annealing)
+
+    check.greater(len(overloads), 0)
+    for overload_func in overloads:
+        overload_params = inspect.signature(overload_func).parameters
+        check.equal(overload_params.keys(), impl_params.keys())
+
+        for name, impl_param in impl_params.items():
+            if name == "merge":
+                continue
+            overload_param = overload_params[name]
+            # rng's default is a single Generator built once at import time
+            # and shared by every caller that omits it; comparing by identity
+            # verifies all three signatures point at that same instance
+            # rather than each constructing their own (which would silently
+            # break the "one shared default rng" invariant).
+            if name == "rng":
+                check.is_(overload_param.default, impl_param.default)
+            else:
+                check.equal(overload_param.default, impl_param.default)
+
+
+def test_simulated_annealing_overload_return_types_are_statically_correct() -> None:
+    """Static-typing check (evaluated by mypy, not at runtime): merge=True
+    (default) must be inferred as Solution, and merge=False as list[Solution].
+    This function's body never actually executes assertions at runtime --
+    assert_type is a no-op there -- its only purpose is to be type-checked."""
+    start = bitstrings.zeros(1, instance_symmetric.size)
+
+    default_result = simulated_annealing(instance_symmetric, start)
+    assert_type(default_result, Solution)
+
+    explicit_merge_result = simulated_annealing(instance_symmetric, start, merge=True)
+    assert_type(explicit_merge_result, Solution)
+
+    unmerged_result = simulated_annealing(instance_symmetric, start, merge=False)
+    assert_type(unmerged_result, list[Solution])

--- a/tests/types/test_bitstring.py
+++ b/tests/types/test_bitstring.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 import pytest_check as check
 
-from qubosolver import bitstring, linalg
+from qubosolver import bitstring, linalg, torch_rng
 
 
 def test_dtype_returns_int8() -> None:
@@ -206,3 +206,39 @@ def test_to_string_length_matches_number_of_elements() -> None:
     bs = bitstring.tensor(data)
     result = bitstring.to_string(bs)
     check.equal(len(result), len(data))
+
+
+def test_rand_creates_int8_vector_of_requested_length() -> None:
+    n = 20
+    result = bitstring.rand(n, rng=torch_rng(0))
+    check.equal(result.dtype, torch.int8)
+    check.equal(result.shape, (n,))
+
+
+def test_rand_creates_empty_vector_when_n_is_zero() -> None:
+    result = bitstring.rand(0, rng=torch_rng(0))
+    check.equal(result.dtype, torch.int8)
+    check.equal(result.shape, (0,))
+
+
+def test_rand_only_contains_zeros_and_ones() -> None:
+    result = bitstring.rand(200, rng=torch_rng(0))
+    check.is_true(torch.all((result == 0) | (result == 1)).item())
+
+
+def test_rand_creates_vector_on_specified_device() -> None:
+    custom_device = torch.device("cpu")
+    result = bitstring.rand(10, device=custom_device, rng=torch_rng(0))
+    check.equal(result.device, custom_device)
+
+
+def test_rand_is_deterministic_with_seeded_rng() -> None:
+    a = bitstring.rand(50, rng=torch_rng(1234))
+    b = bitstring.rand(50, rng=torch_rng(1234))
+    torch.testing.assert_close(a, b)
+
+
+def test_rand_differs_across_seeds() -> None:
+    a = bitstring.rand(50, rng=torch_rng(1))
+    b = bitstring.rand(50, rng=torch_rng(2))
+    check.is_false(torch.equal(a, b))

--- a/tests/types/test_bitstrings.py
+++ b/tests/types/test_bitstrings.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 import pytest_check as check
 
-from qubosolver import bitstring, bitstrings
+from qubosolver import bitstring, bitstrings, torch_rng
 
 
 def test_dtype_returns_int8() -> None:
@@ -198,3 +198,50 @@ def test_to_strings_from_torch_converts_correctly() -> None:
     bs = bitstrings.from_torch(source)
     result = bitstrings.to_strings(bs)
     check.equal(result, ["101", "010"])
+
+
+def test_rand_creates_int8_matrix_of_requested_shape() -> None:
+    count, n_bits = 6, 20
+    result = bitstrings.rand(count, n_bits, rng=torch_rng(0))
+    check.equal(result.dtype, torch.int8)
+    check.equal(result.shape, (count, n_bits))
+
+
+def test_rand_creates_empty_matrix_when_count_is_zero() -> None:
+    result = bitstrings.rand(0, 5, rng=torch_rng(0))
+    check.equal(result.dtype, torch.int8)
+    check.equal(result.shape, (0, 5))
+
+
+def test_rand_creates_empty_matrix_when_n_bits_is_zero() -> None:
+    result = bitstrings.rand(5, 0, rng=torch_rng(0))
+    check.equal(result.dtype, torch.int8)
+    check.equal(result.shape, (5, 0))
+
+
+def test_rand_only_contains_zeros_and_ones() -> None:
+    result = bitstrings.rand(20, 20, rng=torch_rng(0))
+    check.is_true(torch.all((result == 0) | (result == 1)).item())
+
+
+def test_rand_creates_matrix_on_specified_device() -> None:
+    custom_device = torch.device("cpu")
+    result = bitstrings.rand(4, 10, device=custom_device, rng=torch_rng(0))
+    check.equal(result.device, custom_device)
+
+
+def test_rand_is_deterministic_with_seeded_rng() -> None:
+    a = bitstrings.rand(10, 50, rng=torch_rng(1234))
+    b = bitstrings.rand(10, 50, rng=torch_rng(1234))
+    torch.testing.assert_close(a, b)
+
+
+def test_rand_differs_across_seeds() -> None:
+    a = bitstrings.rand(10, 50, rng=torch_rng(1))
+    b = bitstrings.rand(10, 50, rng=torch_rng(2))
+    check.is_false(torch.equal(a, b))
+
+
+def test_rand_rows_are_independent_not_identical() -> None:
+    result = bitstrings.rand(10, 30, rng=torch_rng(0))
+    check.is_false(torch.all(result == result[0]).item())

--- a/tests/types/test_solution.py
+++ b/tests/types/test_solution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 import pytest
 import pytest_check as check
 import torch
@@ -134,3 +136,440 @@ def test_non_integer_counts_is_invalid(instance: Instance) -> None:
     )
     solution.counts = torch.tensor([1.5, 1.5])
     _assert_invalid(solution, instance)
+
+
+def test_deduplicate_sums_counts_for_duplicate_bitstrings(instance: Instance) -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1], [1, 0]]),
+        costs=vector.tensor([1.0, 2.0, 1.0]),
+        counts=vectori.tensor([2, 1, 3]),
+        probabilities=vector.tensor([1 / 3, 1 / 6, 1 / 2]),
+    )
+    solution.deduplicate()
+    _assert_valid(solution, instance)
+    assert len(solution) == 2
+
+    s0 = solution[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 5)
+    check.almost_equal(s0.probability, 5 / 6)
+
+    s1 = solution[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.almost_equal(s1.probability, 1 / 6)
+
+
+def test_deduplicate_keeps_minimum_cost_for_duplicate_bitstrings() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [1, 0], [1, 0]]),
+        costs=vector.tensor([3.0, 1.0, 2.0]),
+        counts=vectori.tensor([1, 1, 1]),
+        probabilities=vector.tensor([1 / 3, 1 / 3, 1 / 3]),
+    )
+    solution.deduplicate()
+    assert len(solution) == 1
+
+    s0 = solution[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+
+
+def test_deduplicate_no_duplicates_is_noop(instance: Instance) -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    solution.deduplicate()
+    _assert_valid(solution, instance)
+    assert len(solution) == 2
+
+    s0 = solution[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+    check.equal(s0.probability, 0.75)
+
+    s1 = solution[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.equal(s1.probability, 0.25)
+
+
+def test_deduplicate_empty_solution_is_noop() -> None:
+    solution = Solution()
+    solution.deduplicate()
+    _assert_valid(solution, Instance())
+    check.is_false(solution)
+
+
+def test_deduplicate_missing_counts_is_skipped() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1], [1, 0]]),
+        costs=vector.tensor([1.0, 2.0, 1.0]),
+    )
+    solution.deduplicate()
+    check.equal(len(solution), 2)
+    check.equal(solution.counts.numel(), 0)
+    check.equal(solution.probabilities.numel(), 0)
+
+
+def test_deduplicate_missing_costs_is_skipped() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1], [1, 0]]),
+        counts=vectori.tensor([2, 1, 3]),
+    )
+    solution.deduplicate()
+    assert len(solution) == 2
+    check.equal(solution.costs.numel(), 0)
+
+    s0 = solution[0]
+    check.equal(s0.string, "01")
+    check.equal(s0.count, 1)
+    check.almost_equal(s0.probability, 1 / 6)
+
+    s1 = solution[1]
+    check.equal(s1.string, "10")
+    check.equal(s1.count, 5)
+    check.almost_equal(s1.probability, 5 / 6)
+
+
+def test_concat_disjoint_bitstrings_concatenates(instance: Instance) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([3]),
+        probabilities=vector.tensor([1.0]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[0, 1]]),
+        costs=vector.tensor([2.0]),
+        counts=vectori.tensor([1]),
+        probabilities=vector.tensor([1.0]),
+    )
+    concatenated = Solution.concat([a, b]).deduplicate()
+    _assert_valid(concatenated, instance)
+    assert len(concatenated) == 2
+
+    s0 = concatenated[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+    check.equal(s0.probability, 0.75)
+
+    s1 = concatenated[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.equal(s1.probability, 0.25)
+
+
+def test_concat_three_solutions(instance: Instance) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([3]),
+        probabilities=vector.tensor([1.0]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[0, 1]]),
+        costs=vector.tensor([2.0]),
+        counts=vectori.tensor([1]),
+        probabilities=vector.tensor([1.0]),
+    )
+    c = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([2]),
+        probabilities=vector.tensor([1.0]),
+    )
+    concatenated = Solution.concat([a, b, c]).deduplicate()
+    _assert_valid(concatenated, instance)
+    assert len(concatenated) == 2
+
+    s0 = concatenated[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 5)
+    check.almost_equal(s0.probability, 5 / 6)
+
+    s1 = concatenated[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.almost_equal(s1.probability, 1 / 6)
+
+
+def test_concat_keeps_duplicate_bitstrings_as_separate_rows(instance: Instance) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([2]),
+        probabilities=vector.tensor([1.0]),
+    )
+    concatenated = Solution.concat([a, b])
+    check.equal(len(concatenated), 3)
+    _assert_invalid(concatenated, instance)
+
+
+def test_concat_then_deduplicate_sums_counts_for_overlapping_bitstrings(
+    instance: Instance,
+) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([2]),
+        probabilities=vector.tensor([1.0]),
+    )
+    merged = Solution.concat([a, b]).deduplicate()
+    _assert_valid(merged, instance)
+    assert len(merged) == 2
+
+    s0 = merged[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 5)
+    check.almost_equal(s0.probability, 5 / 6)
+
+    s1 = merged[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.almost_equal(s1.probability, 1 / 6)
+
+
+def test_concat_unit_counts_sets_counts_to_one_before_dedup(instance: Instance) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 7]),
+        probabilities=vector.tensor([3 / 10, 7 / 10]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([99]),
+        probabilities=vector.tensor([1.0]),
+    )
+    merged = Solution.concat([a, b], unit_counts=True).deduplicate()
+    _assert_valid(merged, instance)
+    assert len(merged) == 2
+
+    s0 = merged[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.count, 2)
+    check.almost_equal(s0.probability, 2 / 3)
+
+    s1 = merged[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.count, 1)
+    check.almost_equal(s1.probability, 1 / 3)
+
+
+def test_concat_unit_counts_without_counts_leaves_probabilities_empty() -> None:
+    a = Solution(bitstrings=bitstrings.tensor([[1, 0]]), costs=vector.tensor([1.0]))
+    b = Solution(bitstrings=bitstrings.tensor([[0, 1]]), costs=vector.tensor([2.0]))
+    merged = Solution.concat([a, b], unit_counts=True)
+    check.equal(merged.counts.tolist(), [1, 1])
+    check.equal(merged.probabilities.numel(), 0)
+
+
+def test_concat_accepts_generator(instance: Instance) -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+        counts=vectori.tensor([3]),
+        probabilities=vector.tensor([1.0]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[0, 1]]),
+        costs=vector.tensor([2.0]),
+        counts=vectori.tensor([1]),
+        probabilities=vector.tensor([1.0]),
+    )
+    concatenated = Solution.concat(s for s in (a, b)).deduplicate()
+    _assert_valid(concatenated, instance)
+    assert len(concatenated) == 2
+
+    s0 = concatenated[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+    check.equal(s0.probability, 0.75)
+
+    s1 = concatenated[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.equal(s1.probability, 0.25)
+
+
+def test_concat_both_empty_is_empty() -> None:
+    concatenated = Solution.concat([Solution(), Solution()])
+    _assert_valid(concatenated, Instance())
+    check.equal(len(concatenated), 0)
+
+
+def test_concat_empty_sequence_is_empty() -> None:
+    concatenated = Solution.concat([])
+    _assert_valid(concatenated, Instance())
+    check.equal(len(concatenated), 0)
+
+
+@pytest.mark.parametrize("empty_first", [True, False])
+def test_concat_one_empty_returns_other(instance: Instance, empty_first: bool) -> None:
+    nonempty = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    a, b = (Solution(), nonempty) if empty_first else (nonempty, Solution())
+    concatenated = Solution.concat([a, b])
+    _assert_valid(concatenated, instance)
+    assert len(concatenated) == 2
+
+    s0 = concatenated[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+    check.equal(s0.probability, 0.75)
+
+    s1 = concatenated[1]
+    check.equal(s1.string, "01")
+    check.equal(s1.cost, 2.0)
+    check.equal(s1.count, 1)
+    check.equal(s1.probability, 0.25)
+
+
+def test_concat_mixed_populated_and_empty_costs_raises() -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        counts=vectori.tensor([2]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[0, 1]]),
+        costs=vector.tensor([1.5]),
+        counts=vectori.tensor([3]),
+    )
+    with pytest.raises(ValueError):
+        Solution.concat([a, b])
+
+
+def test_truncate_keeps_first_k_rows(instance: Instance) -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    solution.truncate(1)
+    _assert_valid(solution, instance)
+    assert len(solution) == 1
+
+    s0 = solution[0]
+    check.equal(s0.string, "10")
+    check.equal(s0.cost, 1.0)
+    check.equal(s0.count, 3)
+    check.equal(s0.probability, 1.0)
+
+
+def test_truncate_recomputes_probabilities_from_counts() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1], [0, 0]]),
+        counts=vectori.tensor([3, 1, 4]),
+        probabilities=vector.tensor([3 / 8, 1 / 8, 4 / 8]),
+    )
+    solution.truncate(2)
+    assert len(solution) == 2
+    check.almost_equal(solution[0].probability, 0.75)
+    check.almost_equal(solution[1].probability, 0.25)
+
+
+def test_truncate_k_greater_than_len_is_noop(instance: Instance) -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    solution.truncate(10)
+    _assert_valid(solution, instance)
+    assert len(solution) == 2
+
+
+def test_truncate_missing_costs_and_counts_is_skipped() -> None:
+    solution = Solution(bitstrings=bitstrings.tensor([[1, 0], [0, 1], [0, 0]]))
+    solution.truncate(2)
+    assert len(solution) == 2
+    check.equal(solution.costs.numel(), 0)
+    check.equal(solution.counts.numel(), 0)
+    check.equal(solution.probabilities.numel(), 0)
+
+
+def test_truncate_empty_solution_is_noop() -> None:
+    solution = Solution()
+    solution.truncate(1)
+    _assert_valid(solution, Instance())
+    check.is_false(solution)
+
+
+def test_truncate_probabilities_without_counts_raises() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1], [0, 0]]),
+        probabilities=vector.tensor([0.375, 0.125, 0.5]),
+    )
+    with pytest.raises(ValueError):
+        solution.truncate(2)
+
+
+def test_deepcopy_is_independent_of_original() -> None:
+    solution = Solution(
+        bitstrings=bitstrings.tensor([[1, 0], [0, 1]]),
+        costs=vector.tensor([1.0, 2.0]),
+        counts=vectori.tensor([3, 1]),
+        probabilities=vector.tensor([0.75, 0.25]),
+    )
+    cloned = copy.deepcopy(solution)
+
+    cloned.bitstrings[0, 0] = 0
+    cloned.costs[0] = 999.0
+    cloned.counts[0] = 42
+    cloned.probabilities[0] = 0.1
+
+    check.equal(solution[0].string, "10")
+    check.equal(solution[0].cost, 1.0)
+    check.equal(solution[0].count, 3)
+    check.equal(solution[0].probability, 0.75)
+
+
+def test_concat_mixed_populated_and_empty_counts_raises() -> None:
+    a = Solution(
+        bitstrings=bitstrings.tensor([[1, 0]]),
+        costs=vector.tensor([1.0]),
+    )
+    b = Solution(
+        bitstrings=bitstrings.tensor([[0, 1]]),
+        costs=vector.tensor([1.5]),
+        counts=vectori.tensor([3]),
+    )
+    with pytest.raises(ValueError):
+        Solution.concat([a, b])


### PR DESCRIPTION
Replaces the sorted top_sol list + seen-set dedup with a dict keyed by a byte-encoded bitstring, shrunk to top_k via heapq.nsmallest once it grows past a threshold. SingleSolution now carries the sample count of the bitstring it wraps, and Solution reports per-bitstring visit counts.

Drops the energy_tol parameter along with the now-dead sa_energy_tol config field, and fixes SimulatedAnnealingSolver.solve(), which still passed the removed qubo= and energy_tol= arguments and would have raised TypeError on every call.

Closes #252 #254