### PR TITLE
[Hotfix] Clamp qoolqit, pulser, and emu-* upper bounds as a hotfix for v0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: mypy
         exclude: examples|docs
         additional_dependencies:
-          - "qoolqit[extras]>=1.1.1" # The version in pyproject.toml must match
+          - "qoolqit[extras]>=1.1.1,<1.3" # The version in pyproject.toml must match
 
 # Cleanup jupyter notebooks
 -   repo: https://github.com/srstevenson/nb-clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,13 @@ dependencies = [
   "scikit-optimize",
   "cplex",
   "pydantic>=2",
-  "qoolqit[extras]>=1.1.1", # The version in .pre-commit-config.yaml must match
+  "qoolqit[extras]>=1.1.1,<1.3", # The version in .pre-commit-config.yaml must match
   "shapely",
+  "pulser<1.9",
+  "pulser-pasqal<0.23",
+  "emu-base<2.8",
+  "emu-sv<2.8",
+  "emu-mps<2.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Newer releases of these packages break qubo-solver 0.8.0. The incompatibility will only be fixed in v1, so clamp qoolqit, pulser, pulser-pasqal, emu-base, emu-sv, and emu-mps to their current minor version series in the meantime, using exclusive upper bounds so patch releases stay allowed. Keep the qoolqit pin synced between pyproject.toml and .pre-commit-config.yaml.