### PR TITLE
[Fix] Bump gh-action-pypi-publish to v1.14.2 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           run: |
             hatch build
         - name: Publish to PyPI
-          uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+          uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         - name: Confirm deployment
           timeout-minutes: 5
           run: |


### PR DESCRIPTION
to fix release 0.8.1 PyPI publish failure

pypa/gh-action-pypi-publish@v1.14.0 rejected wheel metadata with "'2.5' is not a valid metadata version" (InvalidDistribution), since hatchling now emits core metadata v2.5. v1.14.2 adds support for it.